### PR TITLE
[failed test] adding a value after an include

### DIFF
--- a/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentTest.scala
@@ -457,4 +457,14 @@ class ConfigDocumentTest extends TestUtils {
         assertEquals("{ a : {\n     \"a\" : 1,\n     \"b\" : 2\n } }",
             configDocument.withValue("a", configVal).render)
     }
+
+    @Test
+    def configDocumentAddValueAfterInclude {
+        val origText = "include \"application\""
+        val configDocument = ConfigDocumentFactory.parseString(origText)
+
+        assertEquals(
+          "include \"application\"\nfoo : bar",
+            configDocument.withValueText("foo", "bar").render)
+    }
 }


### PR DESCRIPTION
Given a one-line HOCON config file with an `include` (and no newline):
```
include "application"
```

Adding a value with the `ConfigDocument` API will produce an invalid config file:
```
include "application" foo : bar
```