### PR TITLE
Add support for polymorphic type handling in Config Beans

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,8 +38,8 @@ lazy val root = (project in file("."))
   )
   .aggregate(
     testLib, configLib,
-    simpleLibScala, simpleAppScala, complexAppScala,
-    simpleLibJava, simpleAppJava, complexAppJava
+    simpleLibScala, simpleAppScala, complexAppScala, polymorphicAppScala,
+    simpleLibJava, simpleAppJava, complexAppJava, polymorphicAppJava
   )
 
 lazy val configLib =  Project("config", file("config"))
@@ -60,10 +60,12 @@ lazy val testLib = proj("config-test-lib", file("test-lib"))
 lazy val simpleLibScala  = proj("config-simple-lib-scala",  file("examples/scala/simple-lib"))  dependsOn configLib
 lazy val simpleAppScala  = proj("config-simple-app-scala",  file("examples/scala/simple-app"))  dependsOn simpleLibScala
 lazy val complexAppScala = proj("config-complex-app-scala", file("examples/scala/complex-app")) dependsOn simpleLibScala
+lazy val polymorphicAppScala = proj("config-polymorphic-app-scala", file("examples/scala/polymorphic-app")) dependsOn configLib
 
 lazy val simpleLibJava  = proj("config-simple-lib-java",  file("examples/java/simple-lib"))  dependsOn configLib
 lazy val simpleAppJava  = proj("config-simple-app-java",  file("examples/java/simple-app"))  dependsOn simpleLibJava
 lazy val complexAppJava = proj("config-complex-app-java", file("examples/java/complex-app")) dependsOn simpleLibJava
+lazy val polymorphicAppJava = proj("config-polymorphic-app-java", file("examples/java/polymorphic-app")) dependsOn configLib
 
 useGpg := true
 

--- a/config/src/main/java/com/typesafe/config/ConfigSubTypes.java
+++ b/config/src/main/java/com/typesafe/config/ConfigSubTypes.java
@@ -1,0 +1,52 @@
+package com.typesafe.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used with {@link ConfigTypeInfo} to indicate sub-types of
+ * serializable polymorphic types, and to associate logical names used within
+ * config (which is more portable than using physical Java class names).
+ *
+ * Note that just annotating a property or base type with this annotation does
+ * NOT enable polymorphic type handling: in addition, {@link ConfigTypeInfo} or
+ * equivalent (such as enabling of so-called "default typing") annotation is
+ * needed, and only in such case is subtype information used.
+ */
+@Documented
+@Target({
+    ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD,
+    ElementType.METHOD, ElementType.PARAMETER
+})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ConfigSubTypes {
+
+    /**
+     * Subtypes of the annotated type (annotated class, or property value type
+     * associated with the annotated method). These will be checked recursively
+     * so that types can be defined by only including direct subtypes.
+     */
+    Type[] value();
+
+    /**
+     * Definition of a subtype, along with optional name. If name is missing,
+     * class of the type will be checked for {@link ConfigTypeName} annotation;
+     * and if that is also missing or empty, a default name will be constructed.
+     * Default name is usually based on class name.
+     */
+    @interface Type {
+
+        /**
+         * Class of the subtype.
+         */
+        Class<?> value();
+
+        /**
+         * Logical type name used as the type identifier for the class.
+         */
+        String name() default "";
+    }
+}

--- a/config/src/main/java/com/typesafe/config/ConfigTypeInfo.java
+++ b/config/src/main/java/com/typesafe/config/ConfigTypeInfo.java
@@ -1,0 +1,70 @@
+package com.typesafe.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used for configuring details of if and how type information is
+ * used with conversion to Java class, to preserve information about actual
+ * class of Object instances. This is necessarily for polymorphic types, and may
+ * also be needed to link abstract declared types and matching concrete
+ * implementation.
+ */
+@Documented
+@Target({
+    ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD,
+    ElementType.METHOD, ElementType.PARAMETER
+})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ConfigTypeInfo {
+
+    /**
+     * Property name used when for type inclusion method.
+     *
+     * If POJO itself has a property with same name, value of property will be
+     * set with type id metadata: if no such property exists, type id is only
+     * used for determining actual type.
+     */
+    String property() default "type";
+
+    /**
+     * Optional property that can be used to specify default implementation
+     * class to use for deserialization if type identifier is either not
+     * present, or can not be mapped to a registered type (which can occur for
+     * ids, but not when specifying explicit class to use). Property is only
+     * used in deciding what to do for otherwise unmappable cases.
+     *
+     * Note that while this property allows specification of the default
+     * implementation to use, it does not help with structural issues that may
+     * arise if type information is missing. This means that most often this is
+     * used with type-name -based resolution, to cover cases where new sub-types
+     * are added, but base type is not changed to reference new sub-types.
+     *
+     * There are certain special values that indicate alternate behavior:
+     * <ul>
+     *     <li>
+     *         {@link java.lang.Void} means that objects with unmappable (or
+     *         missing) type are to be mapped to null references.
+     *     </li>
+     *     <li>
+     *         Placeholder value of {@link ConfigTypeInfo} (that is, this
+     *         annotation type itself} means "there is no default implementation"
+     *         (in which case an error results from unmappable type).
+     *     </li>
+     * </ul>
+     */
+    Class<?> defaultImpl() default ConfigTypeInfo.class;
+
+    /**
+     * Property that defines whether type identifier value will be passed as
+     * part of config to deserializer (true), or handled and removed by {@link
+     * ConfigBeanFactory} (false).
+     *
+     * Default value is false, meaning that Config handles and removes the type
+     * identifier from config that is passed to {@link ConfigBeanFactory}.
+     */
+    boolean visible() default false;
+}

--- a/config/src/main/java/com/typesafe/config/ConfigTypeName.java
+++ b/config/src/main/java/com/typesafe/config/ConfigTypeName.java
@@ -1,0 +1,22 @@
+package com.typesafe.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used for binding logical name that the annotated class has.
+ */
+@Documented
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ConfigTypeName {
+
+    /**
+     * Logical type name for annotated type. If missing (or defined as Empty
+     * String), defaults to using non-qualified class name as the type.
+     */
+    String value() default "";
+}

--- a/config/src/test/java/beanconfig/polymorphic/PolymorphicWithDefaultImpl.java
+++ b/config/src/test/java/beanconfig/polymorphic/PolymorphicWithDefaultImpl.java
@@ -1,0 +1,45 @@
+package beanconfig.polymorphic;
+
+import com.typesafe.config.ConfigSubTypes;
+import com.typesafe.config.ConfigSubTypes.Type;
+import com.typesafe.config.ConfigTypeInfo;
+
+import java.util.List;
+
+public class PolymorphicWithDefaultImpl {
+
+    @ConfigTypeInfo(defaultImpl = LegacyInter.class)
+    @ConfigSubTypes(value = {
+        @Type(value = MyInter.class, name = "mine")
+    })
+    public interface Inter {}
+
+    public static class MyInter implements Inter {
+
+        private List<String> blah;
+
+        public List<String> getBlah() {
+            return blah;
+        }
+
+        public void setBlah(List<String> blah) {
+            this.blah = blah;
+        }
+    }
+
+    public static class LegacyInter extends MyInter {
+    }
+
+    /*
+     * can use non-deprecated value for the same
+     */
+    @ConfigTypeInfo(defaultImpl = Void.class)
+    public static class DefaultWithVoidAsDefault {}
+
+    /*
+     * one with no defaultImpl nor listed subtypes
+     */
+    @ConfigTypeInfo
+    public abstract static class MysteryPolymorphic {}
+
+}

--- a/config/src/test/java/beanconfig/polymorphic/PolymorphicWithDefaultImplConfigs.java
+++ b/config/src/test/java/beanconfig/polymorphic/PolymorphicWithDefaultImplConfigs.java
@@ -1,0 +1,65 @@
+package beanconfig.polymorphic;
+
+import beanconfig.polymorphic.PolymorphicWithDefaultImpl.DefaultWithVoidAsDefault;
+import beanconfig.polymorphic.PolymorphicWithDefaultImpl.Inter;
+import beanconfig.polymorphic.PolymorphicWithDefaultImpl.MysteryPolymorphic;
+
+public class PolymorphicWithDefaultImplConfigs {
+
+    public static class InnerConfig {
+
+        private Inter object;
+        private Inter array;
+
+        public Inter getObject() {
+            return object;
+        }
+
+        public void setObject(Inter object) {
+            this.object = object;
+        }
+
+        public Inter getArray() {
+            return array;
+        }
+
+        public void setArray(Inter array) {
+            this.array = array;
+        }
+    }
+
+    public static class DefaultWithVoidAsDefaultConfig {
+
+        private DefaultWithVoidAsDefault defaultAsVoid1;
+        private DefaultWithVoidAsDefault defaultAsVoid2;
+
+        public DefaultWithVoidAsDefault getDefaultAsVoid1() {
+            return defaultAsVoid1;
+        }
+
+        public void setDefaultAsVoid1(DefaultWithVoidAsDefault defaultAsVoid1) {
+            this.defaultAsVoid1 = defaultAsVoid1;
+        }
+
+        public DefaultWithVoidAsDefault getDefaultAsVoid2() {
+            return defaultAsVoid2;
+        }
+
+        public void setDefaultAsVoid2(DefaultWithVoidAsDefault defaultAsVoid2) {
+            this.defaultAsVoid2 = defaultAsVoid2;
+        }
+    }
+
+    public static class MysteryPolymorphicConfig {
+
+        private MysteryPolymorphic badType;
+
+        public MysteryPolymorphic getBadType() {
+            return badType;
+        }
+
+        public void setBadType(MysteryPolymorphic badType) {
+            this.badType = badType;
+        }
+    }
+}

--- a/config/src/test/java/beanconfig/polymorphic/Subtypes.java
+++ b/config/src/test/java/beanconfig/polymorphic/Subtypes.java
@@ -1,0 +1,143 @@
+package beanconfig.polymorphic;
+
+import com.typesafe.config.ConfigSubTypes;
+import com.typesafe.config.ConfigSubTypes.Type;
+import com.typesafe.config.ConfigTypeInfo;
+import com.typesafe.config.ConfigTypeName;
+import com.typesafe.config.Optional;
+
+public class Subtypes {
+
+    @ConfigTypeInfo
+    @ConfigSubTypes({
+        @Type(value = SubB.class),
+        @Type(value = SubC.class),
+        @Type(value = SubD.class)
+    })
+    public static abstract class SuperType {
+    }
+
+    @ConfigTypeName("TypeB")
+    public static class SubB extends SuperType {
+
+        private int b = 1;
+
+        public int getB() {
+            return b;
+        }
+
+        public void setB(int b) {
+            this.b = b;
+        }
+    }
+
+    public static class SubC extends SuperType {
+
+        private int c = 2;
+
+        public int getC() {
+            return c;
+        }
+
+        public void setC(int c) {
+            this.c = c;
+        }
+    }
+
+    public static class SubD extends SuperType {
+
+        private int d;
+
+        public int getD() {
+            return d;
+        }
+
+        public void setD(int d) {
+            this.d = d;
+        }
+    }
+
+    @ConfigTypeInfo(defaultImpl = DefaultImpl.class)
+    public static abstract class SuperTypeWithDefault {}
+
+    public static class DefaultImpl extends SuperTypeWithDefault {
+
+        @Optional
+        private int a;
+
+        public int getA() {
+            return a;
+        }
+
+        public void setA(int a) {
+            this.a = a;
+        }
+    }
+
+    @ConfigTypeInfo
+    @ConfigSubTypes({
+        @Type(ImplX.class),
+        @Type(ImplY.class)
+    })
+    public static abstract class BaseX {}
+
+    @ConfigTypeName("x")
+    public static class ImplX extends BaseX {
+
+        private int x;
+
+        public ImplX() {
+        }
+
+        public ImplX(int x) {
+            this.x = x;
+        }
+
+        public int getX() {
+            return x;
+        }
+
+        public void setX(int x) {
+            this.x = x;
+        }
+    }
+
+    @ConfigTypeName("y")
+    public static class ImplY extends BaseX {
+
+        private int y;
+
+        public int getY() {
+            return y;
+        }
+
+        public void setY(int y) {
+            this.y = y;
+        }
+    }
+
+    public static class AtomicWrapper {
+
+        private BaseX value;
+
+        public AtomicWrapper() {
+        }
+
+        public AtomicWrapper(int x) {
+            value = new ImplX(x);
+        }
+
+        public BaseX getDirectValue() {
+            return value;
+        }
+
+        public int getValue() {
+            return ((ImplX) value).getX();
+        }
+
+        public void setValue(int value) {
+            this.value = new ImplX(value);
+        }
+    }
+
+}

--- a/config/src/test/java/beanconfig/polymorphic/SubtypesConfigs.java
+++ b/config/src/test/java/beanconfig/polymorphic/SubtypesConfigs.java
@@ -1,0 +1,75 @@
+package beanconfig.polymorphic;
+
+import beanconfig.polymorphic.Subtypes.AtomicWrapper;
+import beanconfig.polymorphic.Subtypes.SuperType;
+import beanconfig.polymorphic.Subtypes.SuperTypeWithDefault;
+
+public class SubtypesConfigs {
+
+    public static class SuperTypeConfig {
+
+        private SuperType bean1;
+        private SuperType bean2;
+
+        public SuperType getBean1() {
+            return bean1;
+        }
+
+        public void setBean1(SuperType bean1) {
+            this.bean1 = bean1;
+        }
+
+        public SuperType getBean2() {
+            return bean2;
+        }
+
+        public void setBean2(SuperType bean2) {
+            this.bean2 = bean2;
+        }
+    }
+
+    public static class DefaultImplConfig {
+
+        private SuperTypeWithDefault defaultImpl1;
+        private SuperTypeWithDefault defaultImpl2;
+        private SuperTypeWithDefault defaultImpl3;
+
+        public SuperTypeWithDefault getDefaultImpl1() {
+            return defaultImpl1;
+        }
+
+        public void setDefaultImpl1(SuperTypeWithDefault defaultImpl1) {
+            this.defaultImpl1 = defaultImpl1;
+        }
+
+        public SuperTypeWithDefault getDefaultImpl2() {
+            return defaultImpl2;
+        }
+
+        public void setDefaultImpl2(SuperTypeWithDefault defaultImpl2) {
+            this.defaultImpl2 = defaultImpl2;
+        }
+
+        public SuperTypeWithDefault getDefaultImpl3() {
+            return defaultImpl3;
+        }
+
+        public void setDefaultImpl3(SuperTypeWithDefault defaultImpl3) {
+            this.defaultImpl3 = defaultImpl3;
+        }
+    }
+
+    public static class AtomicWrapperConfig {
+
+        private AtomicWrapper atomicWrapper;
+
+        public AtomicWrapper getAtomicWrapper() {
+            return atomicWrapper;
+        }
+
+        public void setAtomicWrapper(AtomicWrapper atomicWrapper) {
+            this.atomicWrapper = atomicWrapper;
+        }
+    }
+
+}

--- a/config/src/test/java/beanconfig/polymorphic/TypeNames.java
+++ b/config/src/test/java/beanconfig/polymorphic/TypeNames.java
@@ -1,0 +1,132 @@
+package beanconfig.polymorphic;
+
+import com.typesafe.config.ConfigSubTypes;
+import com.typesafe.config.ConfigSubTypes.Type;
+import com.typesafe.config.ConfigTypeInfo;
+import com.typesafe.config.ConfigTypeName;
+
+public class TypeNames {
+
+    @ConfigTypeInfo
+    @ConfigSubTypes({
+        @Type(value = Dog.class, name = "doggy"),
+        @Type(Cat.class) /* defaults to "Cat" then */
+    })
+    public static class Animal {
+
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @ConfigSubTypes({
+        @Type(MaineCoon.class),
+        @Type(Persian.class)
+    })
+    public static abstract class Cat extends Animal {
+
+        private boolean purrs;
+
+        public boolean isPurrs() {
+            return purrs;
+        }
+
+        public void setPurrs(boolean purrs) {
+            this.purrs = purrs;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Cat cat = (Cat) o;
+            return purrs == cat.purrs;
+        }
+
+        @Override
+        public int hashCode() {
+            return (purrs ? 1 : 0);
+        }
+    }
+
+    public static class Dog extends Animal {
+
+        private int ageInYears;
+
+        public int getAgeInYears() {
+            return ageInYears;
+        }
+
+        public void setAgeInYears(int ageInYears) {
+            this.ageInYears = ageInYears;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Dog dog = (Dog) o;
+            return ageInYears == dog.ageInYears;
+        }
+
+        @Override
+        public int hashCode() {
+            return ageInYears;
+        }
+
+        @Override
+        public String toString() {
+            return "Dog{" +
+                "ageInYears=" + ageInYears +
+                '}';
+        }
+    }
+
+    /*
+     * Uses default name ("MaineCoon") since there's no @ConfigTypeName,
+     * nor did supertype specify name.
+     */
+    public static class MaineCoon extends Cat {
+
+        public MaineCoon() {
+            super();
+        }
+
+        @Override
+        public String toString() {
+            return "Cat{" +
+                "purrs=" + isPurrs() +
+                '}';
+        }
+    }
+
+    @ConfigTypeName("persialaisKissa")
+    public static class Persian extends Cat {
+
+        public Persian() {
+            super();
+        }
+
+        @Override
+        public String toString() {
+            return "Cat{" +
+                "purrs=" + isPurrs() +
+                '}';
+        }
+    }
+
+}

--- a/config/src/test/java/beanconfig/polymorphic/TypeNamesConfigs.java
+++ b/config/src/test/java/beanconfig/polymorphic/TypeNamesConfigs.java
@@ -1,0 +1,53 @@
+package beanconfig.polymorphic;
+
+import beanconfig.polymorphic.TypeNames.Animal;
+
+import java.util.List;
+
+public class TypeNamesConfigs {
+
+    public static class SingleTypeConfig {
+
+        private Animal dog;
+
+        public Animal getDog() {
+            return dog;
+        }
+
+        public void setDog(Animal dog) {
+            this.dog = dog;
+        }
+    }
+
+    public static class TypeNamesListConfig {
+
+        List<Animal> dogs;
+        List<Animal> cats;
+        List<Animal> animals;
+
+        public List<Animal> getDogs() {
+            return dogs;
+        }
+
+        public void setDogs(List<Animal> dogs) {
+            this.dogs = dogs;
+        }
+
+        public List<Animal> getCats() {
+            return cats;
+        }
+
+        public void setCats(List<Animal> cats) {
+            this.cats = cats;
+        }
+
+        public List<Animal> getAnimals() {
+            return animals;
+        }
+
+        public void setAnimals(List<Animal> animals) {
+            this.animals = animals;
+        }
+    }
+
+}

--- a/config/src/test/java/beanconfig/polymorphic/VisibleTypeId.java
+++ b/config/src/test/java/beanconfig/polymorphic/VisibleTypeId.java
@@ -1,0 +1,33 @@
+package beanconfig.polymorphic;
+
+import com.typesafe.config.ConfigTypeInfo;
+import com.typesafe.config.ConfigTypeName;
+
+public class VisibleTypeId {
+
+    @ConfigTypeInfo(visible = true)
+    @ConfigTypeName("BaseType")
+    public static class PropertyBean {
+
+        private int a = 3;
+
+        private String type;
+
+        public int getA() {
+            return a;
+        }
+
+        public void setA(int a) {
+            this.a = a;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+    }
+
+}

--- a/config/src/test/java/beanconfig/polymorphic/VisibleTypeIdConfigs.java
+++ b/config/src/test/java/beanconfig/polymorphic/VisibleTypeIdConfigs.java
@@ -1,0 +1,20 @@
+package beanconfig.polymorphic;
+
+import beanconfig.polymorphic.VisibleTypeId.PropertyBean;
+
+public class VisibleTypeIdConfigs {
+
+    public static class VisibleTypeConfig {
+
+        private PropertyBean bean;
+
+        public PropertyBean getBean() {
+            return bean;
+        }
+
+        public void setBean(PropertyBean bean) {
+            this.bean = bean;
+        }
+    }
+
+}

--- a/config/src/test/java/beanconfig/polymorphic/WithGenerics.java
+++ b/config/src/test/java/beanconfig/polymorphic/WithGenerics.java
@@ -1,0 +1,56 @@
+package beanconfig.polymorphic;
+
+import com.typesafe.config.ConfigSubTypes;
+import com.typesafe.config.ConfigSubTypes.Type;
+import com.typesafe.config.ConfigTypeInfo;
+
+public class WithGenerics {
+
+    @ConfigTypeInfo(property = "object-type")
+    @ConfigSubTypes({
+        @Type(value = Dog.class, name = "doggy")
+    })
+    public static abstract class Animal {
+
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class Dog extends Animal {
+
+        private int boneCount;
+
+        public Dog() {
+            super();
+        }
+
+        public int getBoneCount() {
+            return boneCount;
+        }
+
+        public void setBoneCount(int boneCount) {
+            this.boneCount = boneCount;
+        }
+    }
+
+    public static class ContainerWithAnimal<T extends Animal> {
+
+        private T animal;
+
+        public void setAnimal(T animal) {
+            this.animal = animal;
+        }
+
+        public T getAnimal() {
+            return animal;
+        }
+    }
+
+}

--- a/config/src/test/java/beanconfig/polymorphic/WithGenericsConfigs.java
+++ b/config/src/test/java/beanconfig/polymorphic/WithGenericsConfigs.java
@@ -1,0 +1,21 @@
+package beanconfig.polymorphic;
+
+import beanconfig.polymorphic.WithGenerics.Animal;
+import beanconfig.polymorphic.WithGenerics.ContainerWithAnimal;
+
+public class WithGenericsConfigs {
+
+    public static class WrapperWithGenericsConfig {
+
+        private ContainerWithAnimal<Animal> wrapperWithDog;
+
+        public ContainerWithAnimal<Animal> getWrapperWithDog() {
+            return wrapperWithDog;
+        }
+
+        public void setWrapperWithDog(ContainerWithAnimal<Animal> wrapperWithDog) {
+            this.wrapperWithDog = wrapperWithDog;
+        }
+    }
+
+}

--- a/config/src/test/java/beanconfig/polymorphic/WithServiceLoader.java
+++ b/config/src/test/java/beanconfig/polymorphic/WithServiceLoader.java
@@ -1,0 +1,43 @@
+package beanconfig.polymorphic;
+
+import com.typesafe.config.ConfigTypeInfo;
+import com.typesafe.config.ConfigTypeName;
+
+public class WithServiceLoader {
+
+    public interface ExampleTag {
+    }
+
+    @ConfigTypeInfo
+    public interface ExampleSPI extends ExampleTag {
+    }
+
+    @ConfigTypeName("a")
+    public static class ImplA implements ExampleSPI {
+
+        private String message;
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+    }
+
+    @ConfigTypeName("b")
+    public static class ImplB implements ExampleSPI {
+
+        private int value;
+
+        public int getValue() {
+            return value;
+        }
+
+        public void setValue(int value) {
+            this.value = value;
+        }
+    }
+
+}

--- a/config/src/test/java/beanconfig/polymorphic/WithServiceLoaderConfigs.java
+++ b/config/src/test/java/beanconfig/polymorphic/WithServiceLoaderConfigs.java
@@ -1,0 +1,31 @@
+package beanconfig.polymorphic;
+
+import beanconfig.polymorphic.WithServiceLoader.ExampleSPI;
+
+import java.util.List;
+
+public class WithServiceLoaderConfigs {
+
+    public static class SimpleServiceLoader {
+
+        private ExampleSPI singleTag;
+        private List<ExampleSPI> otherTags;
+
+        public ExampleSPI getSingleTag() {
+            return singleTag;
+        }
+
+        public void setSingleTag(ExampleSPI singleTag) {
+            this.singleTag = singleTag;
+        }
+
+        public List<ExampleSPI> getOtherTags() {
+            return otherTags;
+        }
+
+        public void setOtherTags(List<ExampleSPI> otherTags) {
+            this.otherTags = otherTags;
+        }
+    }
+
+}

--- a/config/src/test/resources/META-INF/services/beanconfig.polymorphic.WithServiceLoader$ExampleSPI
+++ b/config/src/test/resources/META-INF/services/beanconfig.polymorphic.WithServiceLoader$ExampleSPI
@@ -1,0 +1,2 @@
+beanconfig.polymorphic.WithServiceLoader$ImplA
+beanconfig.polymorphic.WithServiceLoader$ImplB

--- a/config/src/test/resources/META-INF/services/beanconfig.polymorphic.WithServiceLoader$ExampleTag
+++ b/config/src/test/resources/META-INF/services/beanconfig.polymorphic.WithServiceLoader$ExampleTag
@@ -1,0 +1,1 @@
+beanconfig.polymorphic.WithServiceLoader$ExampleSPI

--- a/config/src/test/resources/beanconfig/polymorphic01.conf
+++ b/config/src/test/resources/beanconfig/polymorphic01.conf
@@ -1,0 +1,108 @@
+{
+    "polymorphicWithDefaultImpl": {
+        "object": {
+            "type": "mine"
+            "blah": ["a", "b", "c"]
+        }
+        "array": {
+            "blah": ["a", "b", "c", "d"]
+        }
+        "defaultAsVoid1": {}
+        "defaultAsVoid2": {
+            "bogus": 3
+        }
+        "badType": {
+            "whatever": 13
+        }
+    }
+
+    "subtypes": {
+        "bean1": {
+            "type": "TypeB"
+            "b": 13
+        }
+        "bean2": {
+            "type": "SubD"
+            "d": -4
+        }
+        "defaultImpl1": {
+            "a": 13
+        }
+        "defaultImpl2": {
+            "a": 14
+            "type": "foobar"
+        }
+        "defaultImpl3": {
+            "type": "foobar"
+        }
+        "atomicWrapper": {
+            "value": 3
+        }
+    }
+
+    "typeNames": {
+        "dog": {
+            "type": "doggy"
+            "name": "Smiley"
+            "ageInYears": 1
+        }
+        "dogs": [
+            {
+                "type": "doggy"
+                "name": "Spot"
+                "ageInYears": 3
+            }
+            {
+                "type": "doggy"
+                "name": "Odie"
+                "ageInYears": 7
+            }
+        ]
+        "cats": [
+            {
+                "type": "MaineCoon"
+                "name": "Belzebub"
+                "purrs": true
+            }
+            {
+                "type": "MaineCoon"
+                "name": "Piru"
+                "purrs": false
+            }
+            {
+                "type": "persialaisKissa"
+                "name": "Khomeini"
+                "purrs": true
+            }
+        ]
+        "animals": [
+            {
+                "type": "MaineCoon"
+                "name": "Venla"
+                "purrs": true
+            }
+            {
+                "type": "doggy"
+                "name": "Amadeus"
+                "ageInYears": 13
+            }
+        ]
+    }
+
+    "visibleTypeId": {
+        "bean" {
+            "type": "BaseType"
+            "a": 3
+        }
+    }
+
+    "withGenerics": {
+        "wrapperWithDog": {
+            "animal": {
+                "object-type": "doggy"
+                "name": "Fluffy"
+                "boneCount": 3
+            }
+        }
+    }
+}

--- a/config/src/test/resources/beanconfig/polymorphic01.conf
+++ b/config/src/test/resources/beanconfig/polymorphic01.conf
@@ -105,4 +105,21 @@
             }
         }
     }
+
+    "withServiceLoader": {
+        "singleTag": {
+            "type": "a"
+            "message": "bar"
+        }
+        "otherTags": [
+            {
+                "type": "a"
+                "message": "baz"
+            }
+            {
+                "type": "b"
+                "value": 42
+            }
+        ]
+    }
 }

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigPolymorphicBeanTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigPolymorphicBeanTest.scala
@@ -1,0 +1,189 @@
+package com.typesafe.config.impl
+
+import java.io.{InputStream, InputStreamReader}
+
+import beanconfig.polymorphic.PolymorphicWithDefaultImpl._
+import beanconfig.polymorphic.PolymorphicWithDefaultImplConfigs._
+import beanconfig.polymorphic.Subtypes._
+import beanconfig.polymorphic.SubtypesConfigs._
+import beanconfig.polymorphic.TypeNames._
+import beanconfig.polymorphic.TypeNamesConfigs._
+import beanconfig.polymorphic.VisibleTypeId._
+import beanconfig.polymorphic.VisibleTypeIdConfigs._
+import beanconfig.polymorphic.WithGenericsConfigs._
+import beanconfig.polymorphic.{TypeNames, WithGenerics}
+import com.typesafe.config._
+import org.junit.Assert._
+import org.junit._
+
+import scala.collection.JavaConverters._
+
+class ConfigPolymorphicBeanTest extends TestUtils {
+
+    @Test
+    def testDeserializationWithObject() {
+        val beanConfig: InnerConfig =
+            ConfigBeanFactory.create(loadConfig().getConfig("polymorphicWithDefaultImpl"), classOf[InnerConfig])
+        assertNotNull(beanConfig)
+
+        assertTrue(beanConfig.getObject.isInstanceOf[MyInter])
+        assertFalse(beanConfig.getObject.isInstanceOf[LegacyInter])
+        assertEquals(List("a", "b", "c").asJava, beanConfig.getObject.asInstanceOf[MyInter].getBlah)
+    }
+
+    @Test
+    def testDeserializationWithArray() {
+        val beanConfig: InnerConfig =
+            ConfigBeanFactory.create(loadConfig().getConfig("polymorphicWithDefaultImpl"), classOf[InnerConfig])
+        assertNotNull(beanConfig)
+
+        assertTrue(beanConfig.getArray.isInstanceOf[LegacyInter])
+        assertEquals(List("a", "b", "c", "d").asJava, beanConfig.getArray.asInstanceOf[LegacyInter].getBlah)
+    }
+
+    @Test
+    def testDefaultAsVoid() {
+        val beanConfig: DefaultWithVoidAsDefaultConfig =
+            ConfigBeanFactory.create(loadConfig().getConfig("polymorphicWithDefaultImpl"),
+                classOf[DefaultWithVoidAsDefaultConfig])
+        assertNotNull(beanConfig)
+
+        assertNull(beanConfig.getDefaultAsVoid1)
+        assertNull(beanConfig.getDefaultAsVoid2)
+    }
+
+    @Test
+    def testBadTypeAsNull() {
+        val e = intercept[ConfigException.BadBean] {
+            ConfigBeanFactory.create(loadConfig().getConfig("polymorphicWithDefaultImpl"), classOf[MysteryPolymorphicConfig])
+        }
+        assertTrue("no default implementation", e.getMessage.contains("has no default implementation"))
+    }
+
+    @Test
+    def testDeserialization() {
+        val beanConfig: SuperTypeConfig = ConfigBeanFactory.create(loadConfig().getConfig("subtypes"), classOf[SuperTypeConfig])
+        assertNotNull(beanConfig)
+
+        assertTrue(beanConfig.getBean1.isInstanceOf[SubB])
+        assertEquals(13, beanConfig.getBean1.asInstanceOf[SubB].getB)
+
+        assertTrue(beanConfig.getBean2.isInstanceOf[SubD])
+        assertEquals(-4, beanConfig.getBean2.asInstanceOf[SubD].getD)
+    }
+
+    @Test
+    def testDefaultImpl() {
+        val beanConfig: DefaultImplConfig =
+            ConfigBeanFactory.create(loadConfig().getConfig("subtypes"), classOf[DefaultImplConfig])
+        assertNotNull(beanConfig)
+
+        // first, test with no type information
+        assertTrue(beanConfig.getDefaultImpl1.isInstanceOf[SuperTypeWithDefault])
+        assertEquals(13, beanConfig.getDefaultImpl1.asInstanceOf[DefaultImpl].getA)
+
+        // and then with unmapped info
+        assertTrue(beanConfig.getDefaultImpl2.isInstanceOf[SuperTypeWithDefault])
+        assertEquals(14, beanConfig.getDefaultImpl2.asInstanceOf[DefaultImpl].getA)
+
+        assertTrue(beanConfig.getDefaultImpl3.isInstanceOf[SuperTypeWithDefault])
+        assertEquals(0, beanConfig.getDefaultImpl3.asInstanceOf[DefaultImpl].getA)
+    }
+
+    @Test
+    def testViaAtomic() {
+        val beanConfig: AtomicWrapperConfig =
+            ConfigBeanFactory.create(loadConfig().getConfig("subtypes"), classOf[AtomicWrapperConfig])
+        assertNotNull(beanConfig)
+
+        assertTrue(beanConfig.getAtomicWrapper.getDirectValue.isInstanceOf[ImplX])
+        assertEquals(3, beanConfig.getAtomicWrapper.getValue)
+    }
+
+    @Test
+    def testCreateSpecificType() {
+        val beanConfig: SingleTypeConfig =
+            ConfigBeanFactory.create(loadConfig().getConfig("typeNames"), classOf[SingleTypeConfig])
+        assertNotNull(beanConfig)
+        assertNotNull(beanConfig.getDog)
+
+        assertTrue(beanConfig.getDog.isInstanceOf[TypeNames.Dog])
+        assertEquals("Smiley", beanConfig.getDog.getName)
+        assertEquals(1, beanConfig.getDog.asInstanceOf[TypeNames.Dog].getAgeInYears)
+    }
+
+    @Test
+    def testCreateList() {
+        val beanConfig: TypeNamesListConfig =
+            ConfigBeanFactory.create(loadConfig().getConfig("typeNames"), classOf[TypeNamesListConfig])
+        assertNotNull(beanConfig)
+
+        assertEquals(2, beanConfig.getDogs.size)
+        assertEquals(3, beanConfig.getCats.size)
+        assertEquals(2, beanConfig.getAnimals.size)
+
+        val dogsConfigOne = new Dog()
+        dogsConfigOne.setName("Spot")
+        dogsConfigOne.setAgeInYears(3)
+        val dogsConfigTwo = new Dog()
+        dogsConfigTwo.setName("Odie")
+        dogsConfigTwo.setAgeInYears(7)
+
+        assertEquals(List(dogsConfigOne, dogsConfigTwo).asJava, beanConfig.getDogs)
+
+        val catsConfigOne = new MaineCoon()
+        catsConfigOne.setName("Belzebub")
+        catsConfigOne.setPurrs(true)
+        val catsConfigTwo = new MaineCoon()
+        catsConfigTwo.setName("Piru")
+        catsConfigTwo.setPurrs(false)
+        val catsConfigThree = new Persian()
+        catsConfigThree.setName("Khomeini")
+        catsConfigThree.setPurrs(true)
+
+        assertEquals(List(catsConfigOne, catsConfigTwo, catsConfigThree).asJava, beanConfig.getCats)
+
+        val animalsConfigOne = new MaineCoon()
+        animalsConfigOne.setName("Venla")
+        animalsConfigOne.setPurrs(true)
+        val animalsConfigTwo = new Dog()
+        animalsConfigTwo.setName("Amadeus")
+        animalsConfigTwo.setAgeInYears(13)
+
+        assertEquals(List(animalsConfigOne, animalsConfigTwo).asJava, beanConfig.getAnimals)
+    }
+
+    @Test
+    def testVisible() {
+        val beanConfig: VisibleTypeConfig =
+            ConfigBeanFactory.create(loadConfig().getConfig("visibleTypeId"), classOf[VisibleTypeConfig])
+        assertNotNull(beanConfig)
+
+        assertTrue(beanConfig.getBean.isInstanceOf[PropertyBean])
+        assertEquals("BaseType", beanConfig.getBean.getType)
+        assertEquals(3, beanConfig.getBean.getA)
+    }
+
+    @Test
+    def testWrapperWithGenerics() {
+        val beanConfig: WrapperWithGenericsConfig =
+            ConfigBeanFactory.create(loadConfig().getConfig("withGenerics"), classOf[WrapperWithGenericsConfig])
+        assertNotNull(beanConfig)
+
+        assertTrue(beanConfig.getWrapperWithDog.getAnimal.isInstanceOf[WithGenerics.Dog])
+        assertEquals("Fluffy", beanConfig.getWrapperWithDog.getAnimal.getName)
+        assertEquals(3, beanConfig.getWrapperWithDog.getAnimal.asInstanceOf[WithGenerics.Dog].getBoneCount)
+    }
+
+    private def loadConfig(): Config = {
+        val configIs: InputStream = this.getClass().getClassLoader().getResourceAsStream("beanconfig/polymorphic01.conf")
+        try {
+            val config: Config = ConfigFactory.parseReader(new InputStreamReader(configIs),
+                ConfigParseOptions.defaults.setSyntax(ConfigSyntax.CONF)).resolve
+            config
+        } finally {
+            configIs.close()
+        }
+    }
+
+}

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigPolymorphicBeanTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigPolymorphicBeanTest.scala
@@ -11,6 +11,8 @@ import beanconfig.polymorphic.TypeNamesConfigs._
 import beanconfig.polymorphic.VisibleTypeId._
 import beanconfig.polymorphic.VisibleTypeIdConfigs._
 import beanconfig.polymorphic.WithGenericsConfigs._
+import beanconfig.polymorphic.WithServiceLoader._
+import beanconfig.polymorphic.WithServiceLoaderConfigs._
 import beanconfig.polymorphic.{TypeNames, WithGenerics}
 import com.typesafe.config._
 import org.junit.Assert._
@@ -173,6 +175,23 @@ class ConfigPolymorphicBeanTest extends TestUtils {
         assertTrue(beanConfig.getWrapperWithDog.getAnimal.isInstanceOf[WithGenerics.Dog])
         assertEquals("Fluffy", beanConfig.getWrapperWithDog.getAnimal.getName)
         assertEquals(3, beanConfig.getWrapperWithDog.getAnimal.asInstanceOf[WithGenerics.Dog].getBoneCount)
+    }
+
+    @Test
+    def testSimpleServiceLoader() {
+        val beanConfig: SimpleServiceLoader =
+            ConfigBeanFactory.create(loadConfig().getConfig("withServiceLoader"), classOf[SimpleServiceLoader])
+        assertNotNull(beanConfig)
+
+        assertTrue(beanConfig.getSingleTag.isInstanceOf[ImplA])
+        assertEquals("bar", beanConfig.getSingleTag.asInstanceOf[ImplA].getMessage)
+
+        assertEquals(2, beanConfig.getOtherTags.size)
+
+        assertTrue(beanConfig.getOtherTags.get(0).isInstanceOf[ImplA])
+        assertEquals("baz", beanConfig.getOtherTags.get(0).asInstanceOf[ImplA].getMessage)
+        assertTrue(beanConfig.getOtherTags.get(1).isInstanceOf[ImplB])
+        assertEquals(42, beanConfig.getOtherTags.get(1).asInstanceOf[ImplB].getValue)
     }
 
     private def loadConfig(): Config = {

--- a/examples/java/polymorphic-app/src/main/java/PolymorphicApp.java
+++ b/examples/java/polymorphic-app/src/main/java/PolymorphicApp.java
@@ -1,0 +1,52 @@
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigBeanFactory;
+import com.typesafe.config.ConfigFactory;
+import logging.Appender;
+
+import java.util.List;
+
+class PolymorphicApp {
+
+    public static class LoggerConfiguration {
+
+        private String level;
+        private List<Appender> appenders;
+
+        public String getLevel() {
+            return level;
+        }
+
+        public void setLevel(String level) {
+            this.level = level;
+        }
+
+        public List<Appender> getAppenders() {
+            return appenders;
+        }
+
+        public void setAppenders(List<Appender> appenders) {
+            this.appenders = appenders;
+        }
+    }
+
+    public static void main(String[] args) {
+        // This app is "polymorphic" because we have one interface type with
+        // multiple implementations that are deserialized to correct type based
+        // on the type defined in configuration.
+
+        // Java version showcases two types of defining subtypes and naming
+        // them: defining one subtype in the main interface, and one in the
+        // 'META-INF/services' directory.
+
+        Config config = ConfigFactory.load("polymorphic");
+
+        LoggerConfiguration loggerConfiguration =
+            ConfigBeanFactory.create(config.getConfig("polymorphic-app.logger"), LoggerConfiguration.class);
+
+        String demoMessage = config.getString("polymorphic-app.demo-message");
+
+        for (Appender appender : loggerConfiguration.getAppenders()) {
+            appender.log(demoMessage);
+        }
+    }
+}

--- a/examples/java/polymorphic-app/src/main/java/logging/Appender.java
+++ b/examples/java/polymorphic-app/src/main/java/logging/Appender.java
@@ -1,0 +1,14 @@
+package logging;
+
+import com.typesafe.config.ConfigSubTypes;
+import com.typesafe.config.ConfigSubTypes.Type;
+import com.typesafe.config.ConfigTypeInfo;
+
+@ConfigTypeInfo
+@ConfigSubTypes({
+    @Type(value = ConsoleAppender.class, name = "console")
+})
+public interface Appender {
+
+    void log(String event);
+}

--- a/examples/java/polymorphic-app/src/main/java/logging/ConsoleAppender.java
+++ b/examples/java/polymorphic-app/src/main/java/logging/ConsoleAppender.java
@@ -1,0 +1,20 @@
+package logging;
+
+public class ConsoleAppender implements Appender {
+
+    private String target;
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    @Override
+    public void log(String event) {
+        System.out.printf("Logging to '%s' using console logger: %s\n",
+            target, event);
+    }
+}

--- a/examples/java/polymorphic-app/src/main/java/logging/SyslogAppender.java
+++ b/examples/java/polymorphic-app/src/main/java/logging/SyslogAppender.java
@@ -1,0 +1,41 @@
+package logging;
+
+import com.typesafe.config.ConfigTypeName;
+
+@ConfigTypeName("syslog")
+public class SyslogAppender implements Appender {
+
+    private String host;
+    private int port;
+    private String facility;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getFacility() {
+        return facility;
+    }
+
+    public void setFacility(String facility) {
+        this.facility = facility;
+    }
+
+    @Override
+    public void log(String event) {
+        System.out.printf("Logging to '%s/%d/%s' using syslog logger: %s\n",
+            host, port, facility, event);
+    }
+}

--- a/examples/java/polymorphic-app/src/main/resources/META-INF/services/logging.Appender
+++ b/examples/java/polymorphic-app/src/main/resources/META-INF/services/logging.Appender
@@ -1,0 +1,1 @@
+logging.SyslogAppender

--- a/examples/java/polymorphic-app/src/main/resources/polymorphic.conf
+++ b/examples/java/polymorphic-app/src/main/resources/polymorphic.conf
@@ -1,0 +1,18 @@
+polymorphic-app {
+    logger={
+        level="INFO"
+        appenders=[
+            {
+                type="console"
+                target="stderr"
+            }
+            {
+                type="syslog"
+                host="localhost"
+                port=514
+                facility="local0"
+            }
+        ]
+    }
+    demo-message="hello from java"
+}

--- a/examples/scala/polymorphic-app/src/main/resources/META-INF/services/logging.Appender
+++ b/examples/scala/polymorphic-app/src/main/resources/META-INF/services/logging.Appender
@@ -1,0 +1,2 @@
+logging.ConsoleAppender
+logging.SyslogAppender

--- a/examples/scala/polymorphic-app/src/main/resources/polymorphic.conf
+++ b/examples/scala/polymorphic-app/src/main/resources/polymorphic.conf
@@ -1,0 +1,18 @@
+polymorphic-app {
+    logger={
+        level="INFO"
+        appenders=[
+            {
+                type="console"
+                target="stderr"
+            }
+            {
+                type="syslog"
+                host="localhost"
+                port=514
+                facility="local0"
+            }
+        ]
+    }
+    demo-message="hello from scala"
+}

--- a/examples/scala/polymorphic-app/src/main/scala/PolymorphicApp.scala
+++ b/examples/scala/polymorphic-app/src/main/scala/PolymorphicApp.scala
@@ -1,0 +1,30 @@
+import com.typesafe.config._
+import logging.Appender
+
+import scala.beans.BeanProperty
+import scala.collection.JavaConversions._
+
+object PolymorphicApp extends App {
+
+    class LoggerConfiguration {
+        @BeanProperty var level: String = _
+        @BeanProperty var appenders: java.util.List[Appender] = _
+    }
+
+    // This app is "polymorphic" because we have one interface type with
+    // multiple implementations that are deserialized to correct type based
+    // on the type defined in configuration.
+
+    // Scala version relies on 'META-INF/services' directory for subtype
+    // discovery due to the fact that annotations have some Java specific
+    // elements.
+
+    val config = ConfigFactory.load("polymorphic")
+
+    val loggerConfiguration =
+        ConfigBeanFactory.create(config.getConfig("polymorphic-app.logger"), classOf[LoggerConfiguration])
+
+    val demoMessage = config.getString("polymorphic-app.demo-message")
+
+    loggerConfiguration.getAppenders.toList.foreach(a => a.log(demoMessage))
+}

--- a/examples/scala/polymorphic-app/src/main/scala/logging/Appender.scala
+++ b/examples/scala/polymorphic-app/src/main/scala/logging/Appender.scala
@@ -1,0 +1,9 @@
+package logging
+
+import com.typesafe.config.ConfigTypeInfo
+
+@ConfigTypeInfo
+trait Appender {
+
+    def log(event: String)
+}

--- a/examples/scala/polymorphic-app/src/main/scala/logging/ConsoleAppender.scala
+++ b/examples/scala/polymorphic-app/src/main/scala/logging/ConsoleAppender.scala
@@ -1,0 +1,15 @@
+package logging
+
+import com.typesafe.config.ConfigTypeName
+
+import scala.beans.BeanProperty
+
+@ConfigTypeName("console")
+class ConsoleAppender extends Appender {
+
+    @BeanProperty var target: String = _
+
+    override def log(event: String) {
+        printf("Logging to '%s' using console logger: %s\n", target, event)
+    }
+}

--- a/examples/scala/polymorphic-app/src/main/scala/logging/SyslogAppender.scala
+++ b/examples/scala/polymorphic-app/src/main/scala/logging/SyslogAppender.scala
@@ -1,0 +1,17 @@
+package logging
+
+import com.typesafe.config.ConfigTypeName
+
+import scala.beans.BeanProperty
+
+@ConfigTypeName("syslog")
+class SyslogAppender extends Appender {
+
+    @BeanProperty var host: String = _
+    @BeanProperty var port: Int = _
+    @BeanProperty var facility: String = _
+
+    override def log(event: String) {
+        printf("Logging to '%s/%d/%s' using syslog logger: %s\n", host, port, facility, event)
+    }
+}


### PR DESCRIPTION
Add support for polymorphic type handling in Config Beans

Polymorphic type handling here means ability to enable addition of
enough type information so that deserializer can instantiate correct
subtype of a value.

Issue #507