### PR TITLE
Never pass null ConfigOrigin to PathParser.parsePathNodeExpression

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigDocumentParser.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigDocumentParser.java
@@ -261,7 +261,8 @@ final class ConfigDocumentParser {
         private ConfigNodePath parseKey(Token token) {
             if (flavor == ConfigSyntax.JSON) {
                 if (Tokens.isValueWithType(token, ConfigValueType.STRING)) {
-                    return PathParser.parsePathNodeExpression(Collections.singletonList(token).iterator(), null);
+                    return PathParser.parsePathNodeExpression(Collections.singletonList(token).iterator(),
+                                                              baseOrigin.withLineNumber(lineNumber));
                 } else {
                     throw parseError("Expecting close brace } or a field name here, got "
                             + token);
@@ -279,7 +280,8 @@ final class ConfigDocumentParser {
                 }
 
                 putBack(t); // put back the token we ended with
-                return PathParser.parsePathNodeExpression(expression.iterator(), null);
+                return PathParser.parsePathNodeExpression(expression.iterator(),
+                                                          baseOrigin.withLineNumber(lineNumber));
             }
         }
 


### PR DESCRIPTION
This was causing NPEs on certain parse errors while trying to construct a ConfigException