### PR TITLE
Publish with namespaced JDK9 module name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,9 @@ lazy val configLib =  Project("config", file("config"))
     osgiSettings,
     OsgiKeys.exportPackage := Seq("com.typesafe.config", "com.typesafe.config.impl"),
     publish := sys.error("use publishSigned instead of plain publish"),
-    publishLocal := sys.error("use publishLocalSigned instead of plain publishLocal")
+    publishLocal := sys.error("use publishLocalSigned instead of plain publishLocal"),
+    packageOptions in (Compile, packageBin) +=
+      Package.ManifestAttributes("Automatic-Module-Name" -> "typesafe.config" )
   )
   .enablePlugins(SbtOsgi)
   .dependsOn(testLib % "test->test")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("de.johoop" % "findbugs4sbt" % "1.4.0")
 addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.1.6")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.1")
 
 addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.0.0")


### PR DESCRIPTION
Fixes #546.

Adds `Automatic-Module-Name: typesafe.config`, rather than defaulting to the very generic module name of `config` that the JVM selects.

This PR depends on sbt-osgi 0.9.3 being published for sbt 0.13 (it's been published for sbt 1.0 but not 0.13) to get https://github.com/sbt/sbt-osgi/issues/48.