### PR TITLE
Do cache/lazy load for SimpleConfigObject's hash code to improve heavy throughput use cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 target/
 /bin
 /node_modules
+*.iml

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
@@ -30,6 +30,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
     final private Map<String, AbstractConfigValue> value;
     final private boolean resolved;
     final private boolean ignoresFallbacks;
+    private Integer mapHashValue = null;
 
     SimpleConfigObject(ConfigOrigin origin,
             Map<String, AbstractConfigValue> value, ResolveStatus status,
@@ -596,7 +597,12 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
     public int hashCode() {
         // note that "origin" is deliberately NOT part of equality
         // neither are other "extras" like ignoresFallbacks or resolve status.
-        return mapHash(this);
+        if (this.mapHashValue == null) {
+            return this.mapHashValue=mapHash(this);
+        }
+        else {
+            return mapHashValue;
+        }
     }
 
     @Override


### PR DESCRIPTION
I have a use case that, even parsing and loading the configuration only once, I store some instances in a self-controlled hashmap. In a high throughput system and with big configs, the `mapHash` function becomes a really huge overhead, increasing a lot my CPU time due to redundant computations.

This caching and lazy loading completely solve the problem.