### PR TITLE
sbt 1.1.6 and upgraded plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,7 @@ sudo: false
 cache:
   directories:
     - $HOME/.ivy2/cache
-    # Cache the sbt launcher, currently the Travis VM preinstalls 0.13.5
-    - $HOME/.sbt/launchers/0.13.7
-    # Cache scala, currently the Travis VM preinstalls 2.11.2 & 2.10.4
-    #- $HOME/.sbt/boot/scala-$TRAVIS_SCALA_VERSION
-
-    # Updates regarding Travis VM preinstalls:
-    # https://github.com/travis-ci/travis-cookbooks/blob/master/changes.md
+    - $HOME/.sbt/boot
 
 language: scala
 

--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,7 @@ val sonatype = new PublishToSonatype {
 }
 
 lazy val commonSettings: Seq[Setting[_]] = Def.settings(
-  unpublished,
-  javaVersionPrefix in javaVersionCheck := None
+  unpublished
 )
 
 lazy val root = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@
 // update NEWS, update version in README.md, tag, then
 // publishSigned.
 // Release tags should follow: http://semver.org/
+import scalariform.formatter.preferences._
 
 enablePlugins(GitVersioning)
 git.baseVersion := "1.3.0"
@@ -22,7 +23,10 @@ val sonatype = new PublishToSonatype {
 }
 
 lazy val commonSettings: Seq[Setting[_]] = Def.settings(
-  unpublished
+  unpublished,
+  scalariformPreferences := scalariformPreferences.value
+    .setPreference(IndentSpaces, 4)
+    .setPreference(FirstArgumentOnNewline, Preserve)
 )
 
 lazy val root = (project in file("."))
@@ -49,7 +53,10 @@ lazy val configLib =  Project("config", file("config"))
     publish := sys.error("use publishSigned instead of plain publish"),
     publishLocal := sys.error("use publishLocalSigned instead of plain publishLocal"),
     packageOptions in (Compile, packageBin) +=
-      Package.ManifestAttributes("Automatic-Module-Name" -> "typesafe.config" )
+      Package.ManifestAttributes("Automatic-Module-Name" -> "typesafe.config" ),
+    scalariformPreferences := scalariformPreferences.value
+      .setPreference(IndentSpaces, 4)
+      .setPreference(FirstArgumentOnNewline, Preserve)
   )
   .enablePlugins(SbtOsgi)
   .dependsOn(testLib % "test->test")

--- a/config/build.sbt
+++ b/config/build.sbt
@@ -1,13 +1,3 @@
-import com.typesafe.sbt.SbtScalariform
-import com.typesafe.sbt.SbtScalariform.ScalariformKeys
-import scalariform.formatter.preferences._
-
-val formatPrefs = FormattingPreferences()
-  .setPreference(IndentSpaces, 4)
-
-ScalariformKeys.preferences in Compile := formatPrefs
-ScalariformKeys.preferences in Test := formatPrefs
-
 fork in test := true
 fork in Test := true
 fork in run := true

--- a/config/build.sbt
+++ b/config/build.sbt
@@ -1,11 +1,6 @@
-import de.johoop.findbugs4sbt.FindBugs._
-import de.johoop.findbugs4sbt.{ Effort, ReportType }
-import de.johoop.jacoco4sbt.JacocoPlugin.jacoco
 import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import scalariform.formatter.preferences._
-
-SbtScalariform.scalariformSettings
 
 val formatPrefs = FormattingPreferences()
   .setPreference(IndentSpaces, 4)
@@ -64,15 +59,12 @@ checkstyle in Compile := {
 // add checkstyle as a dependency of doc
 doc in Compile := ((doc in Compile).dependsOn(checkstyle in Compile)).value
 
-findbugsSettings
-findbugsReportType := Some(ReportType.Html)
+findbugsReportType := Some(FindbugsReport.Html)
 findbugsReportPath := Some(crossTarget.value / "findbugs.html")
-findbugsEffort := Effort.Maximum
+findbugsEffort := FindbugsEffort.Maximum
 findbugsMaxMemory := 2000
 
-jacoco.settings
-
-javacOptions in (Compile, compile) ++= Seq("-source", "1.6", "-target", "1.8",
+javacOptions in (Compile, compile) ++= Seq("-source", "1.8", "-target", "1.8",
                                            "-g", "-Xlint:unchecked")
 
 // because we test some global state such as singleton caches,
@@ -86,5 +78,3 @@ javadocSourceBaseUrl := {
   for (gitHead <- com.typesafe.sbt.SbtGit.GitKeys.gitHeadCommit.value)
     yield s"https://github.com/lightbend/config/blob/$gitHead/config/src/main/java"
 }
-
-javaVersionPrefix in javaVersionCheck := Some("1.8")

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
@@ -280,13 +280,13 @@ class ConfigValueTest extends TestUtils {
     }
 
     /**
-      * Reproduces the issue <a href=https://github.com/lightbend/config/issues/461>#461</a>.
-      * <p>
-      * We use a custom de-/serializer that encodes String objects in a JDK-incompatible way. Encoding used here 
-      * is rather simplistic: a long indicating the length in bytes (JDK uses a variable length integer) followed
-      * by the string's bytes. Running this test with the original SerializedConfigValue.readExternal() 
-      * implementation results in an EOFException thrown during deserialization.
-      */
+     * Reproduces the issue <a href=https://github.com/lightbend/config/issues/461>#461</a>.
+     * <p>
+     * We use a custom de-/serializer that encodes String objects in a JDK-incompatible way. Encoding used here
+     * is rather simplistic: a long indicating the length in bytes (JDK uses a variable length integer) followed
+     * by the string's bytes. Running this test with the original SerializedConfigValue.readExternal()
+     * implementation results in an EOFException thrown during deserialization.
+     */
     @Test
     def configConfigCustomSerializable() {
         val aMap = configMap("a" -> 1, "b" -> 2, "c" -> 3)
@@ -295,7 +295,7 @@ class ConfigValueTest extends TestUtils {
 
         assertEquals(expected, actual)
     }
-    
+
     @Test
     def configListEquality() {
         val aScalaSeq = Seq(1, 2, 3) map { intValue(_): AbstractConfigValue }

--- a/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
@@ -551,7 +551,7 @@ abstract trait TestUtils {
             { s: String => s.replace(" ", "") }, // this would break with whitespace in a key or value
             { s: String => s.replace(":", " : ") }, // could break with : in a key or value
             { s: String => s.replace(",", " , ") } // could break with , in a key or value
-            )
+        )
         tests flatMap { t =>
             if (t.whitespaceMatters) {
                 Seq(t)

--- a/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
@@ -198,7 +198,7 @@ class TokenizerTest extends TestUtils {
             """\"\""", // file ends with a backslash
             "$", // file ends with a $
             "${" // file ends with a ${
-            )
+        )
 
         for (t <- invalidTests) {
             val tokenized = tokenizeAsList(t)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.1.6

--- a/project/linksource.scala
+++ b/project/linksource.scala
@@ -26,14 +26,15 @@ object LinkSourcePlugin extends AutoPlugin {
 
       val dir = (target in doc in Compile).value
 
-      javadocSourceBaseUrl.value.foreach { url =>
-        rewriteSourceLinks(dir, url, streams.value.log)
+      (javadocSourceBaseUrl.value, streams.value) match {
+        case (Some(url), streamz) =>
+          rewriteSourceLinks(dir, url, streamz.log)
+        case _ =>
       }
 
       result
     }
   )
-
 
   private def rewriteSourceLinks(dir: File, sourceBaseUrl: String, log: Logger): Unit = {
     // Convert <a href="../../../src-html/com/typesafe/config/Config.html#line.165"> to

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,9 @@
-addSbtPlugin("de.johoop" % "findbugs4sbt" % "1.4.0")
-addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.1.6")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.1.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.3")
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.1")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.0.0")
+addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.1.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
-addSbtPlugin("com.typesafe.sbt" % "sbt-javaversioncheck" % "0.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")


### PR DESCRIPTION
* use sbt 1.1.6
* latest sbt plugins
* removed sbt-javaversioncheck plugin (as it is not available for sbt 1)

The first two commits contain sbt changes, third commit the scalariform reformatted code.