### PR TITLE
Minor documentation correction for config.root().render() under "Debuggin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,8 +758,10 @@ If you have trouble with your configuration, some useful tips.
    output on stderr describing each file that is loaded.
    Note: this feature is not included in the older version in
    Play/Akka 2.0.
- - Use `myConfig.root().render()` to get a `Config` printed out as a
+ - Use `myConfig.root().render()` to get a `Config` as a
    string with comments showing where each value came from.
+   This string can be printed out on console or logged to 
+   a file etc.
 
 ### Supports Java 8 and Later
 


### PR DESCRIPTION
…g Your Configuration"

Looking at the java/scaladoc of ConfigValue.render()  (https://github.com/lightbend/config/blob/master/config/src/main/java/com/typesafe/config/ConfigValue.java#L48-L50)  

and then looking at the implementation of `render()` itself:
https://github.com/lightbend/config/blob/master/config/src/main/java/com/typesafe/config/impl/AbstractConfigValue.java#L364-L374

it appears that `config.root().render()` returns a string that must be printed out, logged etc. Current documentation implies that calling this method will print out the string which seems to be misleading.