### PR TITLE
Add syntax from file name parser option

### DIFF
--- a/config/src/main/java/com/typesafe/config/ConfigParseOptions.java
+++ b/config/src/main/java/com/typesafe/config/ConfigParseOptions.java
@@ -4,6 +4,8 @@
 package com.typesafe.config;
 
 
+import com.typesafe.config.impl.ConfigImplUtil;
+
 /**
  * A set of options related to parsing.
  *
@@ -60,6 +62,18 @@ public final class ConfigParseOptions {
         else
             return new ConfigParseOptions(syntax, this.originDescription, this.allowMissing,
                     this.includer, this.classLoader);
+    }
+
+    /**
+     * Set the file format. If set to null, assume {@link ConfigSyntax#CONF}.
+     *
+     * @param filename
+     *            a configuration file name
+     * @return options with the syntax set
+     */
+    public ConfigParseOptions setSyntaxFromFilename(String filename) {
+        ConfigSyntax syntax = ConfigImplUtil.syntaxFromExtension(filename);
+        return setSyntax(syntax);
     }
 
     /**

--- a/config/src/main/java/com/typesafe/config/impl/ConfigImplUtil.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImplUtil.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigOrigin;
+import com.typesafe.config.ConfigSyntax;
 
 /**
  * Internal implementation detail, not ABI stable, do not touch.
@@ -232,5 +233,24 @@ final public class ConfigImplUtil {
             }
         }
         return nameBuilder.toString();
+    }
+
+    /**
+     * Guess configuration syntax from given filename.
+     *
+     * @param filename configuration filename
+     * @return configuration syntax if a match is found. Otherwise, null.
+     */
+    public static ConfigSyntax syntaxFromExtension(String filename) {
+        if (filename == null)
+            return null;
+        if (filename.endsWith(".json"))
+            return ConfigSyntax.JSON;
+        else if (filename.endsWith(".conf"))
+            return ConfigSyntax.CONF;
+        else if (filename.endsWith(".properties"))
+            return ConfigSyntax.PROPERTIES;
+        else
+            return null;
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/Parseable.java
+++ b/config/src/main/java/com/typesafe/config/impl/Parseable.java
@@ -326,17 +326,6 @@ public abstract class Parseable implements ConfigParseable {
         return getClass().getSimpleName();
     }
 
-    private static ConfigSyntax syntaxFromExtension(String name) {
-        if (name.endsWith(".json"))
-            return ConfigSyntax.JSON;
-        else if (name.endsWith(".conf"))
-            return ConfigSyntax.CONF;
-        else if (name.endsWith(".properties"))
-            return ConfigSyntax.PROPERTIES;
-        else
-            return null;
-    }
-
     private static Reader readerFromStream(InputStream input) {
         return readerFromStream(input, "UTF-8");
     }
@@ -574,7 +563,7 @@ public abstract class Parseable implements ConfigParseable {
 
         @Override
         ConfigSyntax guessSyntax() {
-            return syntaxFromExtension(input.getPath());
+            return ConfigImplUtil.syntaxFromExtension(input.getPath());
         }
 
         @Override
@@ -643,7 +632,7 @@ public abstract class Parseable implements ConfigParseable {
 
         @Override
         ConfigSyntax guessSyntax() {
-            return syntaxFromExtension(input.getName());
+            return ConfigImplUtil.syntaxFromExtension(input.getName());
         }
 
         @Override
@@ -756,7 +745,7 @@ public abstract class Parseable implements ConfigParseable {
 
         @Override
         ConfigSyntax guessSyntax() {
-            return syntaxFromExtension(resource);
+            return ConfigImplUtil.syntaxFromExtension(resource);
         }
 
         static String parent(String resource) {

--- a/config/src/test/resources/test01.properties
+++ b/config/src/test/resources/test01.properties
@@ -2,3 +2,4 @@
 fromProps.abc=abc
 fromProps.one=1
 fromProps.bool=true
+fromProps.specialChars=hello^^

--- a/config/src/test/scala/com/typesafe/config/impl/ParseableReaderTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ParseableReaderTest.scala
@@ -1,0 +1,30 @@
+package com.typesafe.config.impl
+
+import java.io.InputStreamReader
+
+import com.typesafe.config.{ConfigException, ConfigFactory, ConfigParseOptions}
+import org.hamcrest.CoreMatchers.containsString
+import org.junit.Assert.{assertEquals, assertThat}
+import org.junit.Test
+
+class ParseableReaderTest extends TestUtils {
+
+  @Test
+  def parse(): Unit = {
+    val filename = "/test01.properties"
+    val configInput = new InputStreamReader(getClass.getResourceAsStream(filename))
+    val config = ConfigFactory.parseReader(configInput, ConfigParseOptions.defaults()
+      .setSyntaxFromFilename(filename))
+    assertEquals("hello^^", config.getString("fromProps.specialChars"))
+  }
+
+  @Test
+  def parseIncorrectFormat(): Unit = {
+    val filename = "/test01.properties"
+    val configInput = new InputStreamReader(getClass.getResourceAsStream(filename))
+    val e = intercept[ConfigException.Parse] {
+      ConfigFactory.parseReader(configInput)
+    }
+    assertThat(e.getMessage, containsString("Expecting end of input or a comma, got '^'"))
+  }
+}

--- a/config/src/test/scala/com/typesafe/config/impl/UtilTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/UtilTest.scala
@@ -3,6 +3,7 @@
  */
 package com.typesafe.config.impl
 
+import com.typesafe.config.ConfigSyntax
 import org.junit.Assert._
 import org.junit._
 
@@ -89,5 +90,30 @@ class UtilTest extends TestUtils {
         for (s <- lotsOfStrings) {
             roundtripUnquoted(s)
         }
+    }
+
+    @Test
+    def syntaxFromExtensionConf(): Unit = {
+        assertEquals(ConfigSyntax.CONF, ConfigImplUtil.syntaxFromExtension("application.conf"))
+    }
+
+    @Test
+    def syntaxFromExtensionJson(): Unit = {
+        assertEquals(ConfigSyntax.JSON, ConfigImplUtil.syntaxFromExtension("application.json"))
+    }
+
+    @Test
+    def syntaxFromExtensionProperties(): Unit = {
+        assertEquals(ConfigSyntax.PROPERTIES, ConfigImplUtil.syntaxFromExtension("application.properties"))
+    }
+
+    @Test
+    def syntaxFromExtensionUnknown(): Unit = {
+        assertNull(ConfigImplUtil.syntaxFromExtension("application.exe"))
+    }
+
+    @Test
+    def syntaxFromExtensionNull(): Unit = {
+        assertNull(ConfigImplUtil.syntaxFromExtension(null))
     }
 }


### PR DESCRIPTION
Fix #572  

Add parse option to guess syntax from given file name similar to `ConfigFactory.parseFile`