### PR TITLE
added option to switch off validation for ConfigBeanFactory use

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@
 // Release tags should follow: http://semver.org/
 import scalariform.formatter.preferences._
 
-ThisBuild / git.baseVersion         := "1.3.0"
+ThisBuild / git.baseVersion         := "1.3.4"
 ThisBuild / organization            := "com.typesafe"
 ThisBuild / Compile / scalacOptions := List("-unchecked", "-deprecation", "-feature")
 ThisBuild / Test / scalacOptions    := List("-unchecked", "-deprecation", "-feature")

--- a/config/src/main/java/com/typesafe/config/ConfigBeanFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigBeanFactory.java
@@ -44,6 +44,44 @@ public class ConfigBeanFactory {
      *     Can throw the same exceptions as the getters on <code>Config</code>
      */
     public static <T> T create(Config config, Class<T> clazz) {
-        return ConfigBeanImpl.createInternal(config, clazz);
+        return ConfigBeanImpl.createInternal(config, clazz, true);
+    }
+
+    /**
+     * Creates an instance of a class, initializing its fields from a {@link Config}.
+     *
+     * Example usage:
+     *
+     * <pre>
+     * Config configSource = ConfigFactory.load().getConfig("foo");
+     * FooConfig config = ConfigBeanFactory.create(configSource, FooConfig.class);
+     * </pre>
+     *
+     * The Java class should follow JavaBean conventions. Field types
+     * can be any of the types you can normally get from a {@link
+     * Config}, including <code>java.time.Duration</code> or {@link
+     * ConfigMemorySize}. Fields may also be another JavaBean-style
+     * class.
+     *
+     * Fields are mapped to config by converting the config key to
+     * camel case.  So the key <code>foo-bar</code> becomes JavaBean
+     * setter <code>setFooBar</code>.
+     *
+     * @since 1.3.4
+     *
+     * @param config source of config information
+     * @param clazz class to be instantiated
+     * @param validate passing false means that the config will not be validated against the bean's implied schema 
+     * @param <T> the type of the class to be instantiated
+     * @return an instance of the class populated with data from the config
+     * @throws ConfigException.BadBean
+     *     If something is wrong with the JavaBean
+     * @throws ConfigException.ValidationFailed
+     *     If the config doesn't conform to the bean's implied schema
+     * @throws ConfigException
+     *     Can throw the same exceptions as the getters on <code>Config</code>
+     */    
+    public static <T> T create(Config config, Class<T> clazz, boolean validate) {
+        return ConfigBeanImpl.createInternal(config, clazz, validate);
     }
 }

--- a/config/src/main/java/com/typesafe/config/ConfigBeanFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigBeanFactory.java
@@ -44,7 +44,7 @@ public class ConfigBeanFactory {
      *     Can throw the same exceptions as the getters on <code>Config</code>
      */
     public static <T> T create(Config config, Class<T> clazz) {
-        return ConfigBeanImpl.createInternal(config, clazz, true);
+        return ConfigBeanImpl.createInternal(config, clazz, ConfigBeanFactoryOptions.defaults());
     }
 
     /**
@@ -71,7 +71,7 @@ public class ConfigBeanFactory {
      *
      * @param config source of config information
      * @param clazz class to be instantiated
-     * @param validate passing false means that the config will not be validated against the bean's implied schema 
+     * @param options options to be used when creating the bean
      * @param <T> the type of the class to be instantiated
      * @return an instance of the class populated with data from the config
      * @throws ConfigException.BadBean
@@ -81,7 +81,7 @@ public class ConfigBeanFactory {
      * @throws ConfigException
      *     Can throw the same exceptions as the getters on <code>Config</code>
      */    
-    public static <T> T create(Config config, Class<T> clazz, boolean validate) {
-        return ConfigBeanImpl.createInternal(config, clazz, validate);
+    public static <T> T create(Config config, Class<T> clazz, ConfigBeanFactoryOptions options) {
+        return ConfigBeanImpl.createInternal(config, clazz, options);
     }
 }

--- a/config/src/main/java/com/typesafe/config/ConfigBeanFactoryOptions.java
+++ b/config/src/main/java/com/typesafe/config/ConfigBeanFactoryOptions.java
@@ -1,0 +1,60 @@
+/**
+ *   Copyright (C) 2011-2012 Typesafe Inc. <http://typesafe.com>
+ */
+package com.typesafe.config;
+
+
+/**
+ * A set of options related to bean creation.
+ *
+ * <p>
+ * This object is immutable, so the "setters" return a new object.
+ *
+ * <p>
+ * Here is an example of creating a custom {@code ConfigBeanFactoryOptions}:
+ *
+ * <pre>
+ *     ConfigBeanFactoryOptions options = ConfigBeanFactoryOptions.defaults()
+ *         .setAllowMissing(true)
+ * </pre>
+ *
+ */
+public final class ConfigBeanFactoryOptions {
+    final boolean allowMissing;
+
+    private ConfigBeanFactoryOptions(boolean allowMissing) {
+        this.allowMissing = allowMissing;
+    }
+
+    /**
+     * Gets an instance of <code>ConfigBeanFactoryOptions</code> with all fields
+     * set to the default values. Start with this instance and make any
+     * changes you need.
+     * @return the default bean factory options
+     */
+    public static ConfigBeanFactoryOptions defaults() {
+        return new ConfigBeanFactoryOptions(false);
+    }
+
+    /**
+     * Set to false to throw an exception if the bean contains a non-optional field that lacks a configuration setting.
+     * Set to true to just ignore fields missing a configuration thus keeping those to their corresponding default values.
+     *
+     * @param allowMissing true to silently ignore fields missing settings
+     * @return options with the "allow missing" flag set
+     */
+    public ConfigBeanFactoryOptions setAllowMissing(boolean allowMissing) {
+        if (this.allowMissing == allowMissing)
+            return this;
+        else
+            return new ConfigBeanFactoryOptions(allowMissing);
+    }
+
+    /**
+     * Gets the current "allow missing" flag.
+     * @return whether we allow fields missing a config setting
+     */
+    public boolean getAllowMissing() {
+        return allowMissing;
+    }
+}

--- a/config/src/main/java/com/typesafe/config/impl/ConfigBeanImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigBeanImpl.java
@@ -40,7 +40,7 @@ public class ConfigBeanImpl {
      * @param clazz class of the bean
      * @return the bean instance
      */
-    public static <T> T createInternal(Config config, Class<T> clazz) {
+    public static <T> T createInternal(Config config, Class<T> clazz, boolean validate) {
         if (((SimpleConfig)config).root().resolveStatus() != ResolveStatus.RESOLVED)
             throw new ConfigException.NotResolved(
                     "need to Config#resolve() a config before using it to initialize a bean, see the API docs for Config#resolve()");
@@ -77,34 +77,36 @@ public class ConfigBeanImpl {
                 beanProps.add(beanProp);
             }
 
-            // Try to throw all validation issues at once (this does not comprehensively
-            // find every issue, but it should find common ones).
-            List<ConfigException.ValidationProblem> problems = new ArrayList<ConfigException.ValidationProblem>();
-            for (PropertyDescriptor beanProp : beanProps) {
-                Method setter = beanProp.getWriteMethod();
-                Class<?> parameterClass = setter.getParameterTypes()[0];
+            if (validate) {
+                // Try to throw all validation issues at once (this does not comprehensively
+                // find every issue, but it should find common ones).
+                List<ConfigException.ValidationProblem> problems = new ArrayList<ConfigException.ValidationProblem>();
+                for (PropertyDescriptor beanProp : beanProps) {
+                    Method setter = beanProp.getWriteMethod();
+                    Class<?> parameterClass = setter.getParameterTypes()[0];
 
-                ConfigValueType expectedType = getValueTypeOrNull(parameterClass);
-                if (expectedType != null) {
-                    String name = originalNames.get(beanProp.getName());
-                    if (name == null)
-                        name = beanProp.getName();
-                    Path path = Path.newKey(name);
-                    AbstractConfigValue configValue = configProps.get(beanProp.getName());
-                    if (configValue != null) {
-                        SimpleConfig.checkValid(path, expectedType, configValue, problems);
-                    } else {
-                        if (!isOptionalProperty(clazz, beanProp)) {
-                            SimpleConfig.addMissing(problems, expectedType, path, config.origin());
+                    ConfigValueType expectedType = getValueTypeOrNull(parameterClass);
+                    if (expectedType != null) {
+                        String name = originalNames.get(beanProp.getName());
+                        if (name == null)
+                            name = beanProp.getName();
+                        Path path = Path.newKey(name);
+                        AbstractConfigValue configValue = configProps.get(beanProp.getName());
+                        if (configValue != null) {
+                            SimpleConfig.checkValid(path, expectedType, configValue, problems);
+                        } else {
+                            if (!isOptionalProperty(clazz, beanProp)) {
+                                SimpleConfig.addMissing(problems, expectedType, path, config.origin());
+                            }
                         }
                     }
                 }
-            }
 
-            if (!problems.isEmpty()) {
-                throw new ConfigException.ValidationFailed(problems);
+                if (!problems.isEmpty()) {
+                    throw new ConfigException.ValidationFailed(problems);
+                }
             }
-
+            
             // Fill in the bean instance
             T bean = clazz.newInstance();
             for (PropertyDescriptor beanProp : beanProps) {
@@ -114,14 +116,14 @@ public class ConfigBeanImpl {
                 String configPropName = originalNames.get(beanProp.getName());
                 // Is the property key missing in the config?
                 if (configPropName == null) {
-                    // If so, continue if the field is marked as @{link Optional}
-                    if (isOptionalProperty(clazz, beanProp)) {
-                        continue;
-                    }
-                    // Otherwise, raise a {@link Missing} exception right here
-                    throw new ConfigException.Missing(beanProp.getName());
+                    // no need to raise an exception or check for optional,
+                    // that has already been done by the validation step above.
+                    // just continue.
+                    // If validation is switched off, we still want this to work as best effort,
+                    // not to fail completely with an exception.
+                    continue;
                 }
-                Object unwrapped = getValue(clazz, parameterType, parameterClass, config, configPropName);
+                Object unwrapped = getValue(clazz, parameterType, parameterClass, config, configPropName, validate);
                 setter.invoke(bean, unwrapped);
             }
             return bean;
@@ -143,7 +145,7 @@ public class ConfigBeanImpl {
     // types plus you can always use Object, ConfigValue, Config,
     // ConfigObject, etc.  as an escape hatch.
     private static Object getValue(Class<?> beanClass, Type parameterType, Class<?> parameterClass, Config config,
-            String configPropName) {
+            String configPropName, boolean validate) {
         if (parameterClass == Boolean.class || parameterClass == boolean.class) {
             return config.getBoolean(configPropName);
         } else if (parameterClass == Integer.class || parameterClass == int.class) {
@@ -161,9 +163,9 @@ public class ConfigBeanImpl {
         } else if (parameterClass == Object.class) {
             return config.getAnyRef(configPropName);
         } else if (parameterClass == List.class) {
-            return getListValue(beanClass, parameterType, parameterClass, config, configPropName);
+            return getListValue(beanClass, parameterType, parameterClass, config, configPropName, validate);
         } else if (parameterClass == Set.class) {
-            return getSetValue(beanClass, parameterType, parameterClass, config, configPropName);
+            return getSetValue(beanClass, parameterType, parameterClass, config, configPropName, validate);
         } else if (parameterClass == Map.class) {
             // we could do better here, but right now we don't.
             Type[] typeArgs = ((ParameterizedType)parameterType).getActualTypeArguments();
@@ -184,17 +186,17 @@ public class ConfigBeanImpl {
             Enum enumValue = config.getEnum((Class<Enum>) parameterClass, configPropName);
             return enumValue;
         } else if (hasAtLeastOneBeanProperty(parameterClass)) {
-            return createInternal(config.getConfig(configPropName), parameterClass);
+            return createInternal(config.getConfig(configPropName), parameterClass, validate);
         } else {
             throw new ConfigException.BadBean("Bean property " + configPropName + " of class " + beanClass.getName() + " has unsupported type " + parameterType);
         }
     }
 
-    private static Object getSetValue(Class<?> beanClass, Type parameterType, Class<?> parameterClass, Config config, String configPropName) {
-        return new HashSet((List) getListValue(beanClass, parameterType, parameterClass, config, configPropName));
+    private static Object getSetValue(Class<?> beanClass, Type parameterType, Class<?> parameterClass, Config config, String configPropName, boolean validate) {
+        return new HashSet((List) getListValue(beanClass, parameterType, parameterClass, config, configPropName, validate));
     }
 
-    private static Object getListValue(Class<?> beanClass, Type parameterType, Class<?> parameterClass, Config config, String configPropName) {
+    private static Object getListValue(Class<?> beanClass, Type parameterType, Class<?> parameterClass, Config config, String configPropName, boolean validate) {
         Type elementType = ((ParameterizedType)parameterType).getActualTypeArguments()[0];
 
         if (elementType == Boolean.class) {
@@ -227,7 +229,7 @@ public class ConfigBeanImpl {
             List<Object> beanList = new ArrayList<Object>();
             List<? extends Config> configList = config.getConfigList(configPropName);
             for (Config listMember : configList) {
-                beanList.add(createInternal(listMember, (Class<?>) elementType));
+                beanList.add(createInternal(listMember, (Class<?>) elementType, validate));
             }
             return beanList;
         } else {

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
@@ -57,6 +57,22 @@ class ConfigBeanFactoryTest extends TestUtils {
     }
 
     @Test
+    def testAllowMissingPropSetting() {
+        val configIs: InputStream = this.getClass().getClassLoader().getResourceAsStream("beanconfig/beanconfig01.conf")
+        val config: Config = ConfigFactory.parseReader(new InputStreamReader(configIs),
+            ConfigParseOptions.defaults.setSyntax(ConfigSyntax.CONF)).resolve.getConfig("validation")
+        val e = intercept[ConfigException.ValidationFailed] {
+            ConfigBeanFactory.create(config, classOf[ValidationBeanConfig], ConfigBeanFactoryOptions.defaults().setAllowMissing(true))
+        }
+
+        val expecteds = Seq(WrongType("shouldBeInt", 78, "number", "boolean"),
+            WrongType("should-be-boolean", 79, "boolean", "number"),
+            WrongType("should-be-list", 80, "list", "string"))
+
+        checkValidationException(e, expecteds)
+    }
+
+    @Test
     def testCreateBool() {
         val beanConfig: BooleansConfig = ConfigBeanFactory.create(loadConfig().getConfig("booleans"), classOf[BooleansConfig])
         assertNotNull(beanConfig)

--- a/config/src/test/scala/com/typesafe/config/impl/ParseableReaderTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ParseableReaderTest.scala
@@ -2,29 +2,29 @@ package com.typesafe.config.impl
 
 import java.io.InputStreamReader
 
-import com.typesafe.config.{ConfigException, ConfigFactory, ConfigParseOptions}
+import com.typesafe.config.{ ConfigException, ConfigFactory, ConfigParseOptions }
 import org.hamcrest.CoreMatchers.containsString
-import org.junit.Assert.{assertEquals, assertThat}
+import org.junit.Assert.{ assertEquals, assertThat }
 import org.junit.Test
 
 class ParseableReaderTest extends TestUtils {
 
-  @Test
-  def parse(): Unit = {
-    val filename = "/test01.properties"
-    val configInput = new InputStreamReader(getClass.getResourceAsStream(filename))
-    val config = ConfigFactory.parseReader(configInput, ConfigParseOptions.defaults()
-      .setSyntaxFromFilename(filename))
-    assertEquals("hello^^", config.getString("fromProps.specialChars"))
-  }
-
-  @Test
-  def parseIncorrectFormat(): Unit = {
-    val filename = "/test01.properties"
-    val configInput = new InputStreamReader(getClass.getResourceAsStream(filename))
-    val e = intercept[ConfigException.Parse] {
-      ConfigFactory.parseReader(configInput)
+    @Test
+    def parse(): Unit = {
+        val filename = "/test01.properties"
+        val configInput = new InputStreamReader(getClass.getResourceAsStream(filename))
+        val config = ConfigFactory.parseReader(configInput, ConfigParseOptions.defaults()
+            .setSyntaxFromFilename(filename))
+        assertEquals("hello^^", config.getString("fromProps.specialChars"))
     }
-    assertThat(e.getMessage, containsString("Expecting end of input or a comma, got '^'"))
-  }
+
+    @Test
+    def parseIncorrectFormat(): Unit = {
+        val filename = "/test01.properties"
+        val configInput = new InputStreamReader(getClass.getResourceAsStream(filename))
+        val e = intercept[ConfigException.Parse] {
+            ConfigFactory.parseReader(configInput)
+        }
+        assertThat(e.getMessage, containsString("Expecting end of input or a comma, got '^'"))
+    }
 }


### PR DESCRIPTION
Useful in its own right I believe, but this also provides a work around for #440

I have beans that I want instantiated by the config file. But I don't want to set every property of the bean. The bean itself sets default values for some properties. I cannot add the '@Optional' annotation to the bean class properties.

switching off the validation allows this.

(I'm using this library for a live project, it is very useful, thanks for all who have contributed towards it.
I need this capability ASAP, and I would rather use an official release over my patched version.)

I have signed the Typesafe Contributor License Agreement online