### PR TITLE
Project Scala version updated to 1.12.8; all the IDE & compiler warnings fixed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / git.baseVersion         := "1.3.0"
 ThisBuild / organization            := "com.typesafe"
 ThisBuild / Compile / scalacOptions := List("-unchecked", "-deprecation", "-feature")
 ThisBuild / Test / scalacOptions    := List("-unchecked", "-deprecation", "-feature")
-ThisBuild / scalaVersion            := "2.10.6"
+ThisBuild / scalaVersion            := "2.12.8"
 
 ThisBuild / scmInfo                 := Option(
   ScmInfo(url("https://github.com/lightbend/config"), "scm:git@github.com:lightbend/config.git")
@@ -63,7 +63,7 @@ lazy val configLib =  Project("config", file("config"))
   .settings(nocomma {
     autoScalaLibrary                       := false
     crossPaths                             := false
-    libraryDependencies                    += "net.liftweb" %% "lift-json" % "2.5" % Test
+    libraryDependencies                    += "net.liftweb" %% "lift-json" % "3.3.0" % Test
     libraryDependencies                    += "com.novocode" % "junit-interface" % "0.11" % Test
 
     Compile / compile / javacOptions       ++= Seq("-source", "1.8", "-target", "1.8",

--- a/config/src/test/scala/ApiExamples.scala
+++ b/config/src/test/scala/ApiExamples.scala
@@ -52,7 +52,7 @@ class ApiExamples {
         class EnhancedConfig(c: Config) {
             def getAny(path: String): Any = c.getAnyRef(path)
         }
-        implicit def config2enhanced(c: Config) = new EnhancedConfig(c)
+        implicit def config2enhanced(c: Config): EnhancedConfig = new EnhancedConfig(c)
 
         // somewhat nicer now
         val e: Int = conf.getAny("ints.fortyTwo") match {

--- a/config/src/test/scala/Profiling.scala
+++ b/config/src/test/scala/Profiling.scala
@@ -36,7 +36,7 @@ object Util {
     }
 
     def time(body: () => Unit, iterations: Int): Double = {
-        timeHelper(body, iterations, false)
+        timeHelper(body, iterations, retried = false)
     }
 
     def loop(args: Seq[String], body: () => Unit) {
@@ -57,10 +57,10 @@ object FileLoad extends App {
         }
     }
 
-    val ms = Util.time(task, 4000)
+    val ms = Util.time(() => task(), 4000)
     println("file load: " + ms + "ms")
 
-    Util.loop(args, task)
+    Util.loop(args, () => task())
 }
 
 object Resolve extends App {
@@ -73,10 +73,10 @@ object Resolve extends App {
         }
     }
 
-    val ms = Util.time(task, 3000000)
+    val ms = Util.time(() => task(), 3000000)
     println("resolve: " + ms + "ms")
 
-    Util.loop(args, task)
+    Util.loop(args, () => task())
 }
 
 object GetExistingPath extends App {
@@ -88,10 +88,10 @@ object GetExistingPath extends App {
         }
     }
 
-    val ms = Util.time(task, 2000000)
+    val ms = Util.time(() => task(), 2000000)
     println("GetExistingPath: " + ms + "ms")
 
-    Util.loop(args, task)
+    Util.loop(args, () => task())
 }
 
 object GetSeveralExistingPaths extends App {
@@ -105,10 +105,10 @@ object GetSeveralExistingPaths extends App {
         }
     }
 
-    val ms = Util.time(task, 5000000)
+    val ms = Util.time(() => task(), 5000000)
     println("GetSeveralExistingPaths: " + ms + "ms")
 
-    Util.loop(args, task)
+    Util.loop(args, () => task())
 }
 
 object HasPathOnMissing extends App {
@@ -120,10 +120,10 @@ object HasPathOnMissing extends App {
         }
     }
 
-    val ms = Util.time(task, 20000000)
+    val ms = Util.time(() => task(), 20000000)
     println("HasPathOnMissing: " + ms + "ms")
 
-    Util.loop(args, task)
+    Util.loop(args, () => task())
 }
 
 object CatchExceptionOnMissing extends App {
@@ -146,9 +146,9 @@ object CatchExceptionOnMissing extends App {
     }
 
     anotherStackFrame(40) { () =>
-        val ms = Util.time(task, 300000)
+        val ms = Util.time(() => task(), 300000)
         println("CatchExceptionOnMissing: " + ms + "ms")
 
-        Util.loop(args, task)
+        Util.loop(args, () => task())
     }
 }

--- a/config/src/test/scala/Rendering.scala
+++ b/config/src/test/scala/Rendering.scala
@@ -62,7 +62,7 @@ object RenderOptions extends App {
 
     val rendered =
         allBooleanLists(4).foldLeft(0) { (count, values) =>
-            val formatted = values(0)
+            val formatted = values.head
             val originComments = values(1)
             val comments = values(2)
             val json = values(3)

--- a/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfParserTest.scala
@@ -15,14 +15,14 @@ import java.util.Properties
 
 class ConfParserTest extends TestUtils {
 
-    def parseWithoutResolving(s: String) = {
+    def parseWithoutResolving(s: String): AbstractConfigValue = {
         val options = ConfigParseOptions.defaults().
             setOriginDescription("test conf string").
             setSyntax(ConfigSyntax.CONF)
-        Parseable.newString(s, options).parseValue().asInstanceOf[AbstractConfigValue]
+        Parseable.newString(s, options).parseValue()
     }
 
-    def parse(s: String) = {
+    def parse(s: String): AbstractConfigValue = {
         val tree = parseWithoutResolving(s)
 
         // resolve substitutions so we can test problems with that, like cycles or
@@ -38,7 +38,7 @@ class ConfParserTest extends TestUtils {
     @Test
     def invalidConfThrows(): Unit = {
         // be sure we throw
-        for (invalid <- whitespaceVariations(invalidConf, false)) {
+        for (invalid <- whitespaceVariations(invalidConf, validInLift = false)) {
             addOffendingJsonToException("config", invalid.test) {
                 intercept[ConfigException] {
                     parse(invalid.test)
@@ -152,7 +152,7 @@ class ConfParserTest extends TestUtils {
                 }
             } catch {
                 case e: Throwable =>
-                    System.err.println("failed on: '" + invalid + "'");
+                    System.err.println("failed on: '" + invalid + "'")
                     throw e;
             }
         }
@@ -267,9 +267,9 @@ class ConfParserTest extends TestUtils {
             { s: String => s.replace(",\n", "  \n  \n  ,  \n  \n  ") },
             { s: String => dropCurlies(s) })
 
-        var tested = 0;
+        var tested = 0
         for (v <- valids; change <- changes) {
-            tested += 1;
+            tested += 1
             val obj = parseConfig(change(v))
             assertEquals(3, obj.root.size())
             assertEquals("y", obj.getString("a"))
@@ -351,7 +351,7 @@ class ConfParserTest extends TestUtils {
     }
 
     @Test
-    def toStringForParseables() {
+    def toStringForParseablesWorks() {
         // just be sure the toString don't throw, to get test coverage
         val options = ConfigParseOptions.defaults()
         Parseable.newFile(new File("foo"), options).toString
@@ -366,7 +366,7 @@ class ConfParserTest extends TestUtils {
     }
 
     private def assertComments(comments: Seq[String], conf: Config, path: String) {
-        assertEquals(comments, conf.getValue(path).origin().comments().asScala.toSeq)
+        assertEquals(comments, conf.getValue(path).origin().comments().asScala)
     }
 
     private def assertComments(comments: Seq[String], conf: Config, path: String, index: Int) {

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
@@ -7,7 +7,7 @@ import beanconfig.EnumsConfig.{ Solution, Problem }
 import com.typesafe.config._
 
 import java.io.{ InputStream, InputStreamReader }
-import java.time.Duration;
+import java.time.Duration
 
 import beanconfig._
 import org.junit.Assert._
@@ -19,7 +19,7 @@ import scala.collection.mutable.ArrayBuffer
 class ConfigBeanFactoryTest extends TestUtils {
 
     @Test
-    def toCamelCase() {
+    def testToCamelCase() {
         assertEquals("configProp", ConfigImplUtil.toCamelCase("config-prop"))
         assertEquals("configProp", ConfigImplUtil.toCamelCase("configProp"))
         assertEquals("fooBar", ConfigImplUtil.toCamelCase("foo-----bar"))
@@ -122,10 +122,10 @@ class ConfigBeanFactoryTest extends TestUtils {
             ConfigMemorySize.ofBytes(1073741824)),
             beanConfig.getOfMemorySize.asScala)
 
-        val stringsConfigOne = new StringsConfig();
+        val stringsConfigOne = new StringsConfig()
         stringsConfigOne.setAbcd("testAbcdOne")
         stringsConfigOne.setYes("testYesOne")
-        val stringsConfigTwo = new StringsConfig();
+        val stringsConfigTwo = new StringsConfig()
         stringsConfigTwo.setAbcd("testAbcdTwo")
         stringsConfigTwo.setYes("testYesTwo")
 
@@ -155,10 +155,10 @@ class ConfigBeanFactoryTest extends TestUtils {
             ConfigMemorySize.ofBytes(1073741824)),
             beanConfig.getOfMemorySize.asScala)
 
-        val stringsConfigOne = new StringsConfig();
+        val stringsConfigOne = new StringsConfig()
         stringsConfigOne.setAbcd("testAbcdOne")
         stringsConfigOne.setYes("testYesOne")
-        val stringsConfigTwo = new StringsConfig();
+        val stringsConfigTwo = new StringsConfig()
         stringsConfigTwo.setAbcd("testAbcdTwo")
         stringsConfigTwo.setYes("testYesTwo")
 
@@ -200,7 +200,7 @@ class ConfigBeanFactoryTest extends TestUtils {
         assertEquals("abcd", beanConfig.getConfig.getString("abcd"))
         assertEquals(3, beanConfig.getConfigObj.toConfig.getInt("intVal"))
         assertEquals(stringValue("hello world"), beanConfig.getConfigValue)
-        assertEquals(List(1, 2, 3).map(intValue(_)), beanConfig.getList.asScala)
+        assertEquals(List(1, 2, 3).map(intValue), beanConfig.getList.asScala)
         assertEquals(true, beanConfig.getUnwrappedMap.get("shouldBeInt"))
         assertEquals(42, beanConfig.getUnwrappedMap.get("should-be-boolean"))
     }

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentParserTest.scala
@@ -1,6 +1,7 @@
 package com.typesafe.config.impl
 
-import com.typesafe.config.{ ConfigException, ConfigSyntax, ConfigParseOptions }
+import com.typesafe.config.ConfigSyntax.JSON
+import com.typesafe.config.{ ConfigException, ConfigParseOptions, ConfigSyntax }
 import org.junit.Assert._
 import org.junit.Test
 
@@ -14,7 +15,7 @@ class ConfigDocumentParserTest extends TestUtils {
     private def parseJSONFailuresTest(origText: String, containsMessage: String) {
         var exceptionThrown = false
         val e = intercept[ConfigException] {
-            ConfigDocumentParser.parse(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON))
+            ConfigDocumentParser.parse(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(JSON))
         }
         assertTrue(e.getMessage.contains(containsMessage))
     }
@@ -25,7 +26,7 @@ class ConfigDocumentParserTest extends TestUtils {
         assertEquals(expectedRenderedText, node.render())
         assertTrue(node.isInstanceOf[ConfigNodeSimpleValue])
 
-        val nodeJSON = ConfigDocumentParser.parseValue(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON))
+        val nodeJSON = ConfigDocumentParser.parseValue(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(JSON))
         assertEquals(expectedRenderedText, nodeJSON.render())
         assertTrue(nodeJSON.isInstanceOf[ConfigNodeSimpleValue])
     }
@@ -35,7 +36,7 @@ class ConfigDocumentParserTest extends TestUtils {
         assertEquals(origText, node.render())
         assertTrue(node.isInstanceOf[ConfigNodeComplexValue])
 
-        val nodeJSON = ConfigDocumentParser.parseValue(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON))
+        val nodeJSON = ConfigDocumentParser.parseValue(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(JSON))
         assertEquals(origText, nodeJSON.render())
         assertTrue(nodeJSON.isInstanceOf[ConfigNodeComplexValue])
     }
@@ -45,7 +46,7 @@ class ConfigDocumentParserTest extends TestUtils {
         assertEquals(origText, node.render())
 
         val e = intercept[ConfigException] {
-            ConfigDocumentParser.parseValue(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON))
+            ConfigDocumentParser.parseValue(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(JSON))
         }
         assertTrue(e.getMessage.contains(containsMessage))
     }
@@ -58,7 +59,7 @@ class ConfigDocumentParserTest extends TestUtils {
     }
 
     @Test
-    def parseSuccess {
+    def parseSuccess() {
         parseTest("foo:bar")
         parseTest(" foo : bar ")
         parseTest("""include "foo.conf" """)
@@ -185,7 +186,7 @@ class ConfigDocumentParserTest extends TestUtils {
               ]
            }
       """
-        val node = ConfigDocumentParser.parse(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON))
+        val node = ConfigDocumentParser.parse(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(JSON))
         assertEquals(origText, node.render())
     }
 
@@ -249,7 +250,7 @@ class ConfigDocumentParserTest extends TestUtils {
     }
 
     @Test
-    def parseSingleValuesFailures {
+    def parseSingleValuesFailures() {
         // Parse Simple Value throws on leading and trailing whitespace, comments, or newlines
         parseLeadingTrailingFailure("   123")
         parseLeadingTrailingFailure("123   ")
@@ -267,17 +268,17 @@ class ConfigDocumentParserTest extends TestUtils {
 
         // Check that concatenations in JSON will throw an error
         var origText = "123 456 \"abc\""
-        var e = intercept[ConfigException] { ConfigDocumentParser.parseValue(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON)) }
+        var e = intercept[ConfigException] { ConfigDocumentParser.parseValue(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(JSON)) }
         assertTrue("expected message for parsing concat as json", e.getMessage.contains("Parsing JSON and the value set in withValueText was either a concatenation or had trailing whitespace, newlines, or comments"))
 
         // Check that keys with no separators and object values in JSON will throw an error
         origText = """{"foo" { "bar" : 12 } }"""
-        e = intercept[ConfigException] { ConfigDocumentParser.parseValue(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax((ConfigSyntax.JSON))) }
+        e = intercept[ConfigException] { ConfigDocumentParser.parseValue(tokenize(origText), fakeOrigin(), ConfigParseOptions.defaults().setSyntax(JSON)) }
         assertTrue("expected failure for key foo followed by token", e.getMessage.contains("""Key '"foo"' may not be followed by token: '{'"""))
     }
 
     @Test
-    def parseEmptyDocument {
+    def parseEmptyDocument() {
         val node = ConfigDocumentParser.parse(tokenize(""), fakeOrigin(), ConfigParseOptions.defaults())
         assertTrue(node.value().isInstanceOf[ConfigNodeObject])
         assertTrue(node.value().children().isEmpty())

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigDocumentTest.scala
@@ -28,7 +28,7 @@ class ConfigDocumentTest extends TestUtils {
     }
 
     @Test
-    def configDocumentReplace {
+    def configDocumentReplace() {
         // Can handle parsing/replacement with a very simple map
         configDocumentReplaceConfTest("""{"a":1}""", """{"a":2}""", "2", "a")
         configDocumentReplaceJsonTest("""{"a":1}""", """{"a":2}""", "2", "a")
@@ -37,7 +37,7 @@ class ConfigDocumentTest extends TestUtils {
         configDocumentReplaceConfTest("a: b\nc = d", "a: b\nc = 12", "12", "c")
 
         // Can handle parsing/replacement with a complicated map
-        var origText =
+        val origText =
             """{
               "a":123,
               "b": 123.456,

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigSubstitutionTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigSubstitutionTest.scala
@@ -79,7 +79,7 @@ class ConfigSubstitutionTest extends TestUtils {
     def resolveNull() {
         val s = subst("bar.null")
         val v = resolveWithoutFallbacks(s, simpleObject)
-        assertEquals(nullValue(), v)
+        assertEquals(nullValue, v)
     }
 
     @Test
@@ -126,13 +126,13 @@ class ConfigSubstitutionTest extends TestUtils {
 
     @Test
     def resolveMissingInString() {
-        val s = substInString("bar.missing", true /* optional */ )
+        val s = substInString("bar.missing", optional = true)
         val v = resolveWithoutFallbacks(s, simpleObject)
         // absent object becomes empty string
         assertEquals(stringValue("start<>end"), v)
 
         intercept[ConfigException.UnresolvedSubstitution] {
-            val s2 = substInString("bar.missing", false /* optional */ )
+            val s2 = substInString("bar.missing", optional = false)
             resolveWithoutFallbacks(s2, simpleObject)
         }
     }
@@ -654,9 +654,9 @@ class ConfigSubstitutionTest extends TestUtils {
 
         values.put("a", child.relativized(new Path("a")))
         // this "foo" should NOT be used.
-        values.put("foo", stringValue("in parent"));
+        values.put("foo", stringValue("in parent"))
 
-        val resolved = resolve(new SimpleConfigObject(fakeOrigin(), values));
+        val resolved = resolve(new SimpleConfigObject(fakeOrigin(), values))
 
         assertEquals("in child", resolved.getString("a.bar"))
     }
@@ -670,9 +670,9 @@ class ConfigSubstitutionTest extends TestUtils {
 
         values.put("a", child.relativized(new Path("a")))
         // so this "foo" SHOULD be used
-        values.put("foo", stringValue("in parent"));
+        values.put("foo", stringValue("in parent"))
 
-        val resolved = resolve(new SimpleConfigObject(fakeOrigin(), values));
+        val resolved = resolve(new SimpleConfigObject(fakeOrigin(), values))
 
         assertEquals("in parent", resolved.getString("a.bar"))
     }

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
@@ -25,7 +25,7 @@ class ConfigTest extends TestUtils {
             ConfigResolveOptions.noSystem()).asInstanceOf[AbstractConfigObject].toConfig
     }
 
-    def mergeUnresolved(toMerge: AbstractConfigObject*) = {
+    def mergeUnresolved(toMerge: AbstractConfigObject*): AbstractConfigObject = {
         if (toMerge.isEmpty) {
             SimpleConfigObject.empty()
         } else {
@@ -33,7 +33,7 @@ class ConfigTest extends TestUtils {
         }
     }
 
-    def merge(toMerge: AbstractConfigObject*) = {
+    def merge(toMerge: AbstractConfigObject*): AbstractConfigObject = {
         val obj = mergeUnresolved(toMerge: _*)
         resolveNoSystem(obj, obj) match {
             case x: AbstractConfigObject => x
@@ -46,34 +46,31 @@ class ConfigTest extends TestUtils {
         def makeTrees(objects: Seq[AbstractConfigObject]): Iterator[AbstractConfigObject] = {
             objects.length match {
                 case 0 => Iterator.empty
-                case 1 => {
+                case 1 =>
                     Iterator(objects(0))
-                }
-                case 2 => {
+                case 2 =>
                     Iterator(objects(0).withFallback(objects(1)))
-                }
-                case n => {
+                case n =>
                     val leftSplits = for {
-                        i <- (1 until n)
+                        i <- 1 until n
                         pair = objects.splitAt(i)
                         first = pair._1.reduceLeft(_.withFallback(_))
                         second = pair._2.reduceLeft(_.withFallback(_))
                     } yield first.withFallback(second)
                     val rightSplits = for {
-                        i <- (1 until n)
+                        i <- 1 until n
                         pair = objects.splitAt(i)
                         first = pair._1.reduceRight(_.withFallback(_))
                         second = pair._2.reduceRight(_.withFallback(_))
                     } yield first.withFallback(second)
                     leftSplits.iterator ++ rightSplits.iterator
-                }
             }
         }
 
         val trees = makeTrees(allObjects).toSeq
         for (tree <- trees) {
             // if this fails, we were not associative.
-            if (!trees(0).equals(tree))
+            if (!trees.head.equals(tree))
                 throw new AssertionError("Merge was not associative, " +
                     "verify that it should not be, then don't use associativeMerge " +
                     "for this one. two results were: \none: " + trees(0) + "\ntwo: " +
@@ -352,7 +349,7 @@ class ConfigTest extends TestUtils {
         val fixUpCycle = parseObject(""" { "a" : { "b" : { "c" : 57 } } } """)
         val merged = mergeUnresolved(fixUpCycle, cycleObject)
         val v = resolveNoSystem(subst("foo"), merged)
-        assertEquals(intValue(57), v);
+        assertEquals(intValue(57), v)
     }
 
     @Test
@@ -402,7 +399,7 @@ class ConfigTest extends TestUtils {
             val resolved = resolveNoSystem(merged, merged)
 
             assertEquals(3, resolved.root.size())
-            assertEquals(42, resolved.getInt("j"));
+            assertEquals(42, resolved.getInt("j"))
             assertEquals(2, resolved.getInt("b.y"))
             assertEquals(3, resolved.getInt("c.z"))
         }
@@ -568,7 +565,7 @@ class ConfigTest extends TestUtils {
 
         // to get null we have to use the get() method from Map,
         // which takes a key and not a path
-        assertEquals(nullValue(), conf.getObject("nulls").get("null"))
+        assertEquals(nullValue, conf.getObject("nulls").get("null"))
         assertNull(conf.root.get("notinthefile"))
 
         // get stuff with getValue
@@ -951,8 +948,8 @@ class ConfigTest extends TestUtils {
         // include should have overridden the "ints" value in test03
         assertEquals(42, conf.getInt("test01.ints.fortyTwo"))
         // include should have been overridden by 42
-        assertEquals(42, conf.getInt("test01.booleans"));
-        assertEquals(42, conf.getInt("test01.booleans"));
+        assertEquals(42, conf.getInt("test01.booleans"))
+        assertEquals(42, conf.getInt("test01.booleans"))
         // include should have gotten .properties and .json also
         assertEquals("abc", conf.getString("test01.fromProps.abc"))
         assertEquals("A", conf.getString("test01.fromJsonA"))
@@ -983,10 +980,10 @@ class ConfigTest extends TestUtils {
 
         // check that includes into the root object work and that
         // "substitutions look relative-to-included-file first then at root second" works
-        assertEquals("This is in the included file", conf.getString("a"));
-        assertEquals("This is in the including file", conf.getString("b"));
-        assertEquals("This is in the included file", conf.getString("subtree.a"));
-        assertEquals("This is in the including file", conf.getString("subtree.b"));
+        assertEquals("This is in the included file", conf.getString("a"))
+        assertEquals("This is in the including file", conf.getString("b"))
+        assertEquals("This is in the included file", conf.getString("subtree.a"))
+        assertEquals("This is in the including file", conf.getString("subtree.b"))
     }
 
     @Test
@@ -1107,11 +1104,11 @@ class ConfigTest extends TestUtils {
                 .setOriginComments(originComments)
                 .setComments(comments)
                 .setJson(json)
-        }.toSeq
+        }
 
         for (i <- 1 to 10) {
             val numString = i.toString
-            val name = "/test" + { if (numString.size == 1) "0" else "" } + numString
+            val name = "/test" + { if (numString.length == 1) "0" else "" } + numString
             val conf = ConfigFactory.parseResourcesAnySyntax(classOf[ConfigTest], name,
                 ConfigParseOptions.defaults().setAllowMissing(false))
             for (renderOptions <- optionsCombos) {
@@ -1134,7 +1131,7 @@ class ConfigTest extends TestUtils {
                 if (renderOptions.getJson() && !(renderOptions.getComments() || renderOptions.getOriginComments())) {
                     // should get valid JSON if we don't have comments and are resolved
                     val json = try {
-                        ConfigFactory.parseString(resolvedRender, ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON));
+                        ConfigFactory.parseString(resolvedRender, ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON))
                     } catch {
                         case e: Exception =>
                             System.err.println("resolvedRender is not valid json: " + resolvedRender)
@@ -1269,7 +1266,7 @@ class ConfigTest extends TestUtils {
     }
 
     private def runFallbackTest(expected: String, source: String,
-        allowUnresolved: Boolean, resolvers: ConfigResolver*) = {
+        allowUnresolved: Boolean, resolvers: ConfigResolver*): Unit = {
         val unresolved = ConfigFactory.parseString(source)
         var options = ConfigResolveOptions.defaults().setAllowUnresolved(allowUnresolved)
         for (resolver <- resolvers)

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
@@ -140,7 +140,7 @@ class ConfigValueTest extends TestUtils {
             "_z_e_d_C_o_n_f_i_g_V_a_l_u_e00000000000000010C0000_x_p_w_10200000025050000001906" +
             "0000000D000B_f_a_k_e_ _o_r_i_g_i_n090000000100010400000001000103000000010001_x"
 
-        val a = nullValue()
+        val a = nullValue
         val b = checkSerializable(expectedSerialization, a)
         assertNull("b is null", b.unwrapped)
     }
@@ -424,11 +424,11 @@ class ConfigValueTest extends TestUtils {
         longValue(11).toString()
         doubleValue(3.14).toString()
         stringValue("hi").toString()
-        nullValue().toString()
+        nullValue.toString()
         boolValue(true).toString()
         val emptyObj = SimpleConfigObject.empty()
         emptyObj.toString()
-        (new SimpleConfigList(fakeOrigin(), Collections.emptyList[AbstractConfigValue]())).toString()
+        new SimpleConfigList(fakeOrigin(), Collections.emptyList[AbstractConfigValue]()).toString()
         subst("a").toString()
         substInString("b").toString()
         val dm = new ConfigDelayedMerge(fakeOrigin(), List[AbstractConfigValue](subst("a"), subst("b")).asJava)
@@ -499,7 +499,7 @@ class ConfigValueTest extends TestUtils {
         val l: ConfigList = new SimpleConfigList(fakeOrigin(),
             scalaSeq.asJava)
 
-        assertEquals(scalaSeq(0), l.get(0))
+        assertEquals(scalaSeq.head, l.get(0))
         assertEquals(scalaSeq(1), l.get(1))
         assertEquals(scalaSeq(2), l.get(2))
 
@@ -510,7 +510,7 @@ class ConfigValueTest extends TestUtils {
 
         assertEquals(1, l.indexOf(scalaSeq(1)))
 
-        assertFalse(l.isEmpty());
+        assertFalse(l.isEmpty())
 
         assertEquals(scalaSeq, l.iterator().asScala.toSeq)
 
@@ -611,12 +611,12 @@ class ConfigValueTest extends TestUtils {
 
         val obj = parseConfig("{ a : " + a + ", b : " + b + ", c : " + c + ", d : " + d + "}")
         assertEquals(Seq(a, b, c, d),
-            Seq("a", "b", "c", "d") map { obj.getString(_) })
+            Seq("a", "b", "c", "d") map { obj.getString })
 
         // make sure it still works if we're doing concatenation
         val obj2 = parseConfig("{ a : xx " + a + " yy, b : xx " + b + " yy, c : xx " + c + " yy, d : xx " + d + " yy}")
         assertEquals(Seq(a, b, c, d) map { "xx " + _ + " yy" },
-            Seq("a", "b", "c", "d") map { obj2.getString(_) })
+            Seq("a", "b", "c", "d") map { obj2.getString })
     }
 
     @Test
@@ -625,25 +625,25 @@ class ConfigValueTest extends TestUtils {
             val values = new java.util.HashMap[String, AbstractConfigValue]()
             if (!empty)
                 values.put("hello", intValue(37))
-            new SimpleConfigObject(SimpleConfigOrigin.newSimple(desc), values);
+            new SimpleConfigObject(SimpleConfigOrigin.newSimple(desc), values)
         }
         def m(values: AbstractConfigObject*) = {
             AbstractConfigObject.mergeOrigins(values: _*).description()
         }
 
         // simplest case
-        assertEquals("merge of a,b", m(o("a", false), o("b", false)))
+        assertEquals("merge of a,b", m(o("a", empty = false), o("b", empty = false)))
         // combine duplicate "merge of"
-        assertEquals("merge of a,x,y", m(o("a", false), o("merge of x,y", false)))
-        assertEquals("merge of a,b,x,y", m(o("merge of a,b", false), o("merge of x,y", false)))
+        assertEquals("merge of a,x,y", m(o("a", empty = false), o("merge of x,y", empty = false)))
+        assertEquals("merge of a,b,x,y", m(o("merge of a,b", empty = false), o("merge of x,y", empty = false)))
         // ignore empty objects
-        assertEquals("a", m(o("foo", true), o("a", false)))
+        assertEquals("a", m(o("foo", empty = true), o("a", empty = false)))
         // unless they are all empty, pick the first one
-        assertEquals("foo", m(o("foo", true), o("a", true)))
+        assertEquals("foo", m(o("foo", empty = true), o("a", empty = true)))
         // merge just one
-        assertEquals("foo", m(o("foo", false)))
+        assertEquals("foo", m(o("foo", empty = false)))
         // merge three
-        assertEquals("merge of a,b,c", m(o("a", false), o("b", false), o("c", false)))
+        assertEquals("merge of a,b,c", m(o("a", empty = false), o("b", empty = false), o("c", empty = false)))
     }
 
     @Test
@@ -661,7 +661,7 @@ class ConfigValueTest extends TestUtils {
         assertTrue(obj.hasPath("b"))
 
         // hasPath() is false for null values but containsKey is true
-        assertEquals(nullValue(), obj.root.get("a"))
+        assertEquals(nullValue, obj.root.get("a"))
         assertTrue(obj.root.containsKey("a"))
         assertFalse(obj.hasPath("a"))
 
@@ -729,7 +729,7 @@ class ConfigValueTest extends TestUtils {
         assertEquals(-1, noFilename.lineNumber())
 
         assertEquals("foo: 3", filenameWithLine.description())
-        assertEquals("bar: 4", noFilenameWithLine.description());
+        assertEquals("bar: 4", noFilenameWithLine.description())
 
         assertEquals(3, filenameWithLine.lineNumber())
         assertEquals(4, noFilenameWithLine.lineNumber())
@@ -944,10 +944,10 @@ class ConfigValueTest extends TestUtils {
         })
         def top(v: SimpleConfigList) = v.origin
         def middle(v: SimpleConfigList) = v.get(0).origin
-        def bottom(v: SimpleConfigList) = if (v.get(0).isInstanceOf[ConfigList])
-            Some(v.get(0).asInstanceOf[ConfigList].get(0).origin)
-        else
-            None
+        def bottom(v: SimpleConfigList) = v.get(0) match {
+            case list: ConfigList => Some(list.get(0).origin)
+            case _ => None
+        }
 
         //System.err.println("values=\n  " + values.map(v => top(v).description + ", " + middle(v).description + ", " + bottom(v).map(_.description)).mkString("\n  "))
         for (v <- values) {

--- a/config/src/test/scala/com/typesafe/config/impl/EquivalentsTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/EquivalentsTest.scala
@@ -63,7 +63,7 @@ class EquivalentsTest extends TestUtils {
             val (originals, others) = files.partition({ f => f.getName().startsWith("original.") })
             if (originals.isEmpty)
                 throw new RuntimeException("Need a file named 'original' in " + equiv.getPath())
-            if (originals.size > 1)
+            if (originals.length > 1)
                 throw new RuntimeException("Multiple 'original' files in " + equiv.getPath() + ": " + originals)
             val original = parse(originals(0))
 

--- a/config/src/test/scala/com/typesafe/config/impl/HttpTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/HttpTest.scala
@@ -92,7 +92,7 @@ object HttpTest {
 
     private var server: Option[ToyHttp] = None
 
-    def port = server.map(_.port).getOrElse(throw new Exception("http server isn't running"))
+    def port: Int = server.map(_.port).getOrElse(throw new Exception("http server isn't running"))
     def baseUrl = s"http://127.0.0.1:$port"
 
     private def handleThreeTypes(request: Request, json: String, props: String, hocon: String): Response = {

--- a/config/src/test/scala/com/typesafe/config/impl/JsonTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/JsonTest.scala
@@ -3,29 +3,28 @@
  */
 package com.typesafe.config.impl
 
+import java.io.Reader
+import java.util
+
+import com.typesafe.config._
+import net.liftweb.{ json => lift }
 import org.junit.Assert._
 import org.junit._
-import net.liftweb.{ json => lift }
-import java.io.Reader
-import java.io.StringReader
-import com.typesafe.config._
-import java.util.HashMap
-import java.util.Collections
 
 class JsonTest extends TestUtils {
 
     def parse(s: String): ConfigValue = {
         val options = ConfigParseOptions.defaults().
             setOriginDescription("test json string").
-            setSyntax(ConfigSyntax.JSON);
-        Parseable.newString(s, options).parseValue();
+            setSyntax(ConfigSyntax.JSON)
+        Parseable.newString(s, options).parseValue()
     }
 
     def parseAsConf(s: String): ConfigValue = {
         val options = ConfigParseOptions.defaults().
             setOriginDescription("test conf string").
-            setSyntax(ConfigSyntax.CONF);
-        Parseable.newString(s, options).parseValue();
+            setSyntax(ConfigSyntax.CONF)
+        Parseable.newString(s, options).parseValue()
     }
 
     private[this] def toLift(value: ConfigValue): lift.JValue = {
@@ -56,13 +55,11 @@ class JsonTest extends TestUtils {
 
         liftValue match {
             case lift.JObject(fields) =>
-                val m = new HashMap[String, AbstractConfigValue]()
+                val m = new util.HashMap[String, AbstractConfigValue]()
                 fields.foreach({ field => m.put(field.name, fromLift(field.value)) })
                 new SimpleConfigObject(fakeOrigin(), m)
             case lift.JArray(values) =>
-                new SimpleConfigList(fakeOrigin(), values.map(fromLift(_)).asJava)
-            case lift.JField(name, value) =>
-                throw new IllegalStateException("either JField was a toplevel from lift-json or this function is buggy")
+                new SimpleConfigList(fakeOrigin(), values.map(fromLift).asJava)
             case lift.JInt(i) =>
                 if (i.isValidInt) intValue(i.intValue) else longValue(i.longValue)
             case lift.JBool(b) =>
@@ -147,7 +144,7 @@ class JsonTest extends TestUtils {
         var tested = 0
 
         // be sure we do the same thing as Lift when we build our JSON "DOM"
-        for (valid <- whitespaceVariations(validJson, true)) {
+        for (valid <- whitespaceVariations(validJson, validInLift = true)) {
             val liftAST = if (valid.liftBehaviorUnexpected) {
                 SimpleConfigObject.empty()
             } else {

--- a/config/src/test/scala/com/typesafe/config/impl/ParseableReaderTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ParseableReaderTest.scala
@@ -2,29 +2,29 @@ package com.typesafe.config.impl
 
 import java.io.InputStreamReader
 
-import com.typesafe.config.{ConfigException, ConfigFactory, ConfigParseOptions}
+import com.typesafe.config.{ ConfigException, ConfigFactory, ConfigParseOptions }
 import org.hamcrest.CoreMatchers.containsString
-import org.junit.Assert.{assertEquals, assertThat}
+import org.junit.Assert.{ assertEquals, assertThat }
 import org.junit.Test
 
 class ParseableReaderTest extends TestUtils {
 
-  @Test
-  def parse(): Unit = {
-    val filename = "/test01.properties"
-    val configInput = new InputStreamReader(getClass.getResourceAsStream(filename))
-    val config = ConfigFactory.parseReader(configInput, ConfigParseOptions.defaults()
-      .setSyntaxFromFilename(filename))
-    assertEquals("hello^^", config.getString("fromProps.specialChars"))
-  }
-
-  @Test
-  def parseIncorrectFormat(): Unit = {
-    val filename = "/test01.properties"
-    val configInput = new InputStreamReader(getClass.getResourceAsStream(filename))
-    val e = intercept[ConfigException.Parse] {
-      ConfigFactory.parseReader(configInput)
+    @Test
+    def parse(): Unit = {
+        val filename = "/test01.properties"
+        val configInput = new InputStreamReader(getClass.getResourceAsStream(filename))
+        val config = ConfigFactory.parseReader(configInput, ConfigParseOptions.defaults()
+            .setSyntaxFromFilename(filename))
+        assertEquals("hello^^", config.getString("fromProps.specialChars"))
     }
-    assertThat(e.getMessage, containsString("Expecting end of input or a comma, got '^'"))
-  }
+
+    @Test
+    def parseIncorrectFormat(): Unit = {
+        val filename = "/test01.properties"
+        val configInput = new InputStreamReader(getClass.getResourceAsStream(filename))
+        val e = intercept[ConfigException.Parse] {
+            ConfigFactory.parseReader(configInput)
+        }
+        assertThat(e.getMessage, containsString("Expecting end of input or a comma, got '^'"))
+    }
 }

--- a/config/src/test/scala/com/typesafe/config/impl/PathTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/PathTest.scala
@@ -15,13 +15,13 @@ class PathTest extends TestUtils {
         // note: foo.bar is a single key here
         val a = Path.newKey("foo.bar")
         // check that newKey worked
-        assertEquals(path("foo.bar"), a);
+        assertEquals(path("foo.bar"), a)
         val sameAsA = Path.newKey("foo.bar")
         val differentKey = Path.newKey("hello")
         // here foo.bar is two elements
         val twoElements = Path.newPath("foo.bar")
         // check that newPath worked
-        assertEquals(path("foo", "bar"), twoElements);
+        assertEquals(path("foo", "bar"), twoElements)
         val sameAsTwoElements = Path.newPath("foo.bar")
 
         checkEqualObjects(a, a)

--- a/config/src/test/scala/com/typesafe/config/impl/PropertiesTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/PropertiesTest.scala
@@ -108,7 +108,7 @@ class PropertiesTest extends TestUtils {
 
         val conf = ConfigFactory.parseProperties(props, ConfigParseOptions.defaults())
         val reference = ConfigFactory.parseString("{ a : [0,1,2,3,4] }")
-        assertEquals(Seq(0, 1, 2, 3, 4), conf.getIntList("a").asScala.toSeq)
+        assertEquals(Seq(0, 1, 2, 3, 4), conf.getIntList("a").asScala)
         conf.checkValid(reference)
     }
 

--- a/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
@@ -574,7 +574,7 @@ abstract trait TestUtils {
     protected def intValue(i: Int) = new ConfigInt(fakeOrigin(), i, null)
     protected def longValue(l: Long) = new ConfigLong(fakeOrigin(), l, null)
     protected def boolValue(b: Boolean) = new ConfigBoolean(fakeOrigin(), b)
-    protected def nullValue() = new ConfigNull(fakeOrigin())
+    protected def nullValue = new ConfigNull(fakeOrigin())
     protected def stringValue(s: String) = new ConfigString.Quoted(fakeOrigin(), s)
     protected def doubleValue(d: Double) = new ConfigDouble(fakeOrigin(), d, null)
 

--- a/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TokenizerTest.scala
@@ -202,8 +202,8 @@ class TokenizerTest extends TestUtils {
 
         for (t <- invalidTests) {
             val tokenized = tokenizeAsList(t)
-            val maybeProblem = tokenized.find(Tokens.isProblem(_))
-            assertTrue(s"expected failure for <$t> but got ${t}", maybeProblem.isDefined)
+            val maybeProblem = tokenized.find(Tokens.isProblem)
+            assertTrue(s"expected failure for <$t> but got $t", maybeProblem.isDefined)
         }
     }
 
@@ -247,9 +247,9 @@ class TokenizerTest extends TestUtils {
         abstract class NumberTest(val s: String, val result: Token)
         case class LongTest(override val s: String, override val result: Token) extends NumberTest(s, result)
         case class DoubleTest(override val s: String, override val result: Token) extends NumberTest(s, result)
-        implicit def pair2inttest(pair: (String, Int)) = LongTest(pair._1, tokenLong(pair._2))
-        implicit def pair2longtest(pair: (String, Long)) = LongTest(pair._1, tokenLong(pair._2))
-        implicit def pair2doubletest(pair: (String, Double)) = DoubleTest(pair._1, tokenDouble(pair._2))
+        implicit def pair2inttest(pair: (String, Int)): LongTest = LongTest(pair._1, tokenLong(pair._2))
+        implicit def pair2longtest(pair: (String, Long)): LongTest = LongTest(pair._1, tokenLong(pair._2))
+        implicit def pair2doubletest(pair: (String, Double)): DoubleTest = DoubleTest(pair._1, tokenDouble(pair._2))
 
         val tests = List[NumberTest](("1", 1),
             ("1.2", 1.2),
@@ -302,7 +302,7 @@ class TokenizerTest extends TestUtils {
         for (invalid <- "+`^?!@*&\\") {
             val tokenized = tokenizeAsList(invalid.toString)
             assertEquals(3, tokenized.size)
-            assertEquals(Tokens.START, tokenized(0))
+            assertEquals(Tokens.START, tokenized.head)
             assertEquals(Tokens.END, tokenized(2))
             val problem = tokenized(1)
             assertTrue("reserved char is a problem", Tokens.isProblem(problem))

--- a/config/src/test/scala/com/typesafe/config/impl/ToyHttp.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ToyHttp.scala
@@ -25,10 +25,7 @@ final class ToyHttp(handler: ToyHttp.Request => ToyHttp.Response) {
     private final val serverSocket = new ServerSocket()
     serverSocket.bind(new InetSocketAddress("127.0.0.1", 0))
     final val port = serverSocket.getLocalPort
-    private final val thread = new Thread(new Runnable() {
-        override def run() =
-            mainLoop();
-    })
+    private final val thread = new Thread(() => mainLoop())
 
     thread.setDaemon(true)
     thread.setName("ToyHttp")
@@ -118,8 +115,8 @@ final class ToyHttp(handler: ToyHttp.Request => ToyHttp.Response) {
         //val stuff = new java.io.ByteArrayOutputStream
         //val writer = new PrintWriter(new OutputStreamWriter(stuff, StandardCharsets.UTF_8))
         val writer = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8))
-        val dateFormat = new SimpleDateFormat("E, d MMM yyyy HH:mm:ss 'GMT'", Locale.US);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        val dateFormat = new SimpleDateFormat("E, d MMM yyyy HH:mm:ss 'GMT'", Locale.US)
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"))
 
         writer.append(s"HTTP/1.1 ${response.code} ${codeText(response.code)}\r\n")
         writer.append(s"Date: ${dateFormat.format(new Date)}\r\n")

--- a/config/src/test/scala/com/typesafe/config/impl/UnitParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/UnitParserTest.scala
@@ -44,7 +44,7 @@ class UnitParserTest extends TestUtils {
     }
 
     @Test
-    def parsePeriod() = {
+    def parsePeriod(): Unit = {
         val oneYears = List(
             "1y", "1 y", "1year", "1 years", "   1y   ", "   1   y    ",
             "365", "365d", "365 d", "365 days", "   365   days   ", "365day",
@@ -157,7 +157,7 @@ class UnitParserTest extends TestUtils {
     @Test
     def parseHugeMemorySizes(): Unit = {
         def parseMem(s: String): Long = SimpleConfig.parseBytes(s, fakeOrigin(), "test")
-        def assertOutOfRange(s: String) = {
+        def assertOutOfRange(s: String): Unit = {
             val fail = intercept[ConfigException.BadValue] {
                 parseMem(s)
             }

--- a/config/src/test/scala/com/typesafe/config/impl/UtilTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/UtilTest.scala
@@ -58,7 +58,7 @@ class UtilTest extends TestUtils {
         assertTrue(ConfigImplUtil.equalsHandlingNull("", ""))
     }
 
-    val lotsOfStrings = (invalidJson ++ validConf).map(_.test)
+    val lotsOfStrings: List[String] = (invalidJson ++ validConf).map(_.test)
 
     private def roundtripJson(s: String) {
         val rendered = ConfigImplUtil.renderJsonString(s)

--- a/examples/scala/complex-app/src/main/scala/ComplexApp.scala
+++ b/examples/scala/complex-app/src/main/scala/ComplexApp.scala
@@ -35,7 +35,7 @@ object ComplexApp extends App {
     //////////
 
     // "config2" shows how to configure a library with a custom settings subtree
-    val config2 = ConfigFactory.load("complex2");
+    val config2 = ConfigFactory.load("complex2")
 
     // use the config ourselves
     println("config2, complex-app.something=" + config2.getString("complex-app.something"))

--- a/examples/scala/simple-lib/src/main/scala/simplelib/SimpleLib.scala
+++ b/examples/scala/simple-lib/src/main/scala/simplelib/SimpleLib.scala
@@ -40,9 +40,9 @@ class SimpleLibSettings(config: Config) {
 
     // note that these fields are NOT lazy, because if we're going to
     // get any exceptions, we want to get them on startup.
-    val foo = config.getString("simple-lib.foo")
-    val hello = config.getString("simple-lib.hello")
-    val whatever = config.getString("simple-lib.whatever")
+    val foo: String = config.getString("simple-lib.foo")
+    val hello: String = config.getString("simple-lib.hello")
+    val whatever: String = config.getString("simple-lib.whatever")
 }
 
 // This is a different way to do SimpleLibContext, using the

--- a/project/linksource.scala
+++ b/project/linksource.scala
@@ -1,4 +1,4 @@
-import sbt._
+import sbt.{Def, _}
 import Keys._
 import plugins.JvmPlugin
 
@@ -12,7 +12,7 @@ object LinkSourcePlugin extends AutoPlugin {
 
   override def trigger = allRequirements
   override def requires = JvmPlugin
-  override lazy val projectSettings = Seq(
+  override lazy val projectSettings: Seq[Def.Setting[_ >: Option[String] with Task[Seq[String]] with Task[File] <: Product]] = Seq(
     javadocSourceBaseUrl := None,
     javacOptions in (Compile, doc) := {
       val old = (javacOptions in doc).value


### PR DESCRIPTION
As discussed in https://github.com/lightbend/config/pull/568 .

`lift-json` was also bumped as there was no longer any suitable version for Scala 2.12.x.

Also fixed compiler warnings (e.g. _eta expansion of parameterless methods is deprecated_) as well as some rarther non-controversial IDE warnings (e.g. redundant semicolons and such).