### PR TITLE
Use AdoptOpenJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,24 @@
 # use Docker-based container (instead of OpenVZ)
 sudo: false
 
-cache:
-  directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot
-
 language: scala
 
-jdk:
-  - oraclejdk8
+before_install:
+  # using jabba for custom jdk management
+  - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | bash && . ~/.jabba/jabba.sh
+  - jabba install adopt@1.8.202-08
+  - java -version
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test doc
 
+before_cache:
   # Remove to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" -delete
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot
+    - $HOME/.jabba/jdk


### PR DESCRIPTION
Oracle JDK 8 is [end of life](https://www.oracle.com/technetwork/java/java-se-support-roadmap.html) as of this month. Therefore switch to [AdoptOpenJDK](https://adoptopenjdk.net/support.html) Java 8 SDK builds.

This PR uses [jabba](https://github.com/shyiko/jabba) for JDK mangement.