### PR TITLE
Bean validation config to allow missing values or other settings

### DIFF
--- a/config/src/main/java/com/typesafe/config/ConfigBeanFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigBeanFactory.java
@@ -44,6 +44,44 @@ public class ConfigBeanFactory {
      *     Can throw the same exceptions as the getters on <code>Config</code>
      */
     public static <T> T create(Config config, Class<T> clazz) {
-        return ConfigBeanImpl.createInternal(config, clazz);
+        return ConfigBeanImpl.createInternal(config, clazz, ConfigBeanFactoryOptions.defaults());
+    }
+
+    /**
+     * Creates an instance of a class, initializing its fields from a {@link Config}.
+     *
+     * Example usage:
+     *
+     * <pre>
+     * Config configSource = ConfigFactory.load().getConfig("foo");
+     * FooConfig config = ConfigBeanFactory.create(configSource, FooConfig.class);
+     * </pre>
+     *
+     * The Java class should follow JavaBean conventions. Field types
+     * can be any of the types you can normally get from a {@link
+     * Config}, including <code>java.time.Duration</code> or {@link
+     * ConfigMemorySize}. Fields may also be another JavaBean-style
+     * class.
+     *
+     * Fields are mapped to config by converting the config key to
+     * camel case.  So the key <code>foo-bar</code> becomes JavaBean
+     * setter <code>setFooBar</code>.
+     *
+     * @since 1.3.4
+     *
+     * @param config source of config information
+     * @param clazz class to be instantiated
+     * @param options options to be used when creating the bean
+     * @param <T> the type of the class to be instantiated
+     * @return an instance of the class populated with data from the config
+     * @throws ConfigException.BadBean
+     *     If something is wrong with the JavaBean
+     * @throws ConfigException.ValidationFailed
+     *     If the config doesn't conform to the bean's implied schema
+     * @throws ConfigException
+     *     Can throw the same exceptions as the getters on <code>Config</code>
+     */
+    public static <T> T create(Config config, Class<T> clazz, ConfigBeanFactoryOptions options) {
+        return ConfigBeanImpl.createInternal(config, clazz, options);
     }
 }

--- a/config/src/main/java/com/typesafe/config/ConfigBeanFactoryOptions.java
+++ b/config/src/main/java/com/typesafe/config/ConfigBeanFactoryOptions.java
@@ -1,0 +1,61 @@
+/**
+ *   Copyright (C) 2011-2012 Typesafe Inc. <http://typesafe.com>
+ */
+package com.typesafe.config;
+
+
+/**
+ * A set of options related to bean creation.
+ *
+ * <p>
+ * This object is immutable, so the "setters" return a new object.
+ *
+ * <p>
+ * Here is an example of creating a custom {@code ConfigBeanFactoryOptions}:
+ *
+ * <pre>
+ *     ConfigBeanFactoryOptions options = ConfigBeanFactoryOptions.defaults()
+ *         .setAllowMissing(true)
+ * </pre>
+ *
+ */
+public final class ConfigBeanFactoryOptions {
+    final boolean allowMissing;
+
+    private ConfigBeanFactoryOptions(boolean allowMissing) {
+        this.allowMissing = allowMissing;
+    }
+
+    /**
+     * Gets an instance of <code>ConfigBeanFactoryOptions</code> with all fields
+     * set to the default values. Start with this instance and make any
+     * changes you need.
+     * @return the default bean factory options
+     */
+    public static ConfigBeanFactoryOptions defaults() {
+        return new ConfigBeanFactoryOptions(false);
+    }
+
+    /**
+     * Set to false to throw an exception if the bean contains a non-optional field that lacks a configuration setting.
+     * Set to true to just ignore fields missing a configuration thus keeping those to their corresponding default values.
+     * Attempting to assign a value incompatible with the target field type will still throw an error
+     *
+     * @param allowMissing true to silently ignore fields missing settings
+     * @return options with the "allow missing" flag set
+     */
+    public ConfigBeanFactoryOptions setAllowMissing(boolean allowMissing) {
+        if (this.allowMissing == allowMissing)
+            return this;
+        else
+            return new ConfigBeanFactoryOptions(allowMissing);
+    }
+
+    /**
+     * Gets the current "allow missing" flag.
+     * @return whether we allow fields missing a config setting
+     */
+    public boolean getAllowMissing() {
+        return allowMissing;
+    }
+}

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
@@ -57,6 +57,22 @@ class ConfigBeanFactoryTest extends TestUtils {
     }
 
     @Test
+    def testAllowMissingPropSetting() {
+        val configIs: InputStream = this.getClass().getClassLoader().getResourceAsStream("beanconfig/beanconfig01.conf")
+        val config: Config = ConfigFactory.parseReader(new InputStreamReader(configIs),
+            ConfigParseOptions.defaults.setSyntax(ConfigSyntax.CONF)).resolve.getConfig("validation")
+        val e = intercept[ConfigException.ValidationFailed] {
+            ConfigBeanFactory.create(config, classOf[ValidationBeanConfig], ConfigBeanFactoryOptions.defaults().setAllowMissing(true))
+        }
+
+        val expecteds = Seq(WrongType("shouldBeInt", 78, "number", "boolean"),
+            WrongType("should-be-boolean", 79, "boolean", "number"),
+            WrongType("should-be-list", 80, "list", "string"))
+
+        checkValidationException(e, expecteds)
+    }
+
+    @Test
     def testCreateBool() {
         val beanConfig: BooleansConfig = ConfigBeanFactory.create(loadConfig().getConfig("booleans"), classOf[BooleansConfig])
         assertNotNull(beanConfig)


### PR DESCRIPTION
_Continuation of https://github.com/lightbend/config/pull/602. Taking into account the feedback, etc_

The purpose of this change is to provide a mechanism to configure the bean factory internal workings, and in this particular case, to provide a setting to allow missing field values and keep whatever value was originally assigned to the bean or null, instead of throwing an a validation error.
By default such config is disabled, to keep the current behavior as it is and provide a configuration mechanism similar to other sections of the library