### PR TITLE
add new Rust port to Other APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,6 +893,10 @@ format.
 
   * https://github.com/akkadotnet/HOCON
 
+#### Rust port
+
+  * https://github.com/mockersf/hocon.rs
+
 #### Linting tool
 
    * A web based linting tool http://www.hoconlint.com/


### PR DESCRIPTION
I just finished my Rust port of the HOCON specifications and would like to have it mentioned in the README.
To help my tests, I also created https://github.com/mockersf/hocon-test-suite which is a small set of reference HOCON files and how they would render as JSON to be able to compare my results with the official API. I think it would be great to have something similar officially.