### PR TITLE
Added reference to args4c for command-line-to-config utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,7 @@ format.
   * Cedi Config https://github.com/ccadllc/cedi-config
   * Cfg https://github.com/carueda/cfg
   * circe-config https://github.com/circe/circe-config
+  * args4c https://github.com/aaronp/args4c
 
 #### Clojure wrappers for the Java library
 


### PR DESCRIPTION
It seemed there wasn't a library to bridge the gap between the main entry point and running an app based on a Config.

I've added a link to consider 'args4c', which exposes some utilities for converting command-line arguments into a lightbend config