### PR TITLE
Fix compiler warnings in tests

### DIFF
--- a/config/src/test/scala/ApiExamples.scala
+++ b/config/src/test/scala/ApiExamples.scala
@@ -7,6 +7,7 @@ import com.typesafe.config._
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import language.implicitConversions
+import java.util.concurrent.TimeUnit.MILLISECONDS
 
 /**
  * This is to show how the API works and to be sure it's usable
@@ -23,7 +24,7 @@ class ApiExamples {
         val a: Int = conf.getInt("ints.fortyTwo")
         val child: Config = conf.getConfig("ints")
         val b: Int = child.getInt("fortyTwo")
-        val ms: Long = conf.getMilliseconds("durations.halfSecond")
+        val ms: Long = conf.getDuration("durations.halfSecond", MILLISECONDS)
 
         // a Config has an associated tree of values, with a ConfigObject
         // at the root. The ConfigObject implements java.util.Map

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
@@ -3,7 +3,7 @@
  */
 package com.typesafe.config.impl
 
-import java.time.temporal.{ ChronoUnit, TemporalUnit }
+import java.time.temporal.ChronoUnit
 
 import org.junit.Assert._
 import org.junit._
@@ -629,11 +629,11 @@ class ConfigTest extends TestUtils {
         }
 
         intercept[ConfigException.Null] {
-            conf.getMilliseconds("nulls.null")
+            conf.getDuration("nulls.null")
         }
 
         intercept[ConfigException.Null] {
-            conf.getNanoseconds("nulls.null")
+            conf.getDuration("nulls.null", NANOSECONDS)
         }
 
         intercept[ConfigException.Null] {
@@ -662,11 +662,11 @@ class ConfigTest extends TestUtils {
         }
 
         intercept[ConfigException.WrongType] {
-            conf.getMilliseconds("ints")
+            conf.getDuration("ints")
         }
 
         intercept[ConfigException.WrongType] {
-            conf.getNanoseconds("ints")
+            conf.getDuration("ints", NANOSECONDS)
         }
 
         intercept[ConfigException.WrongType] {
@@ -693,11 +693,11 @@ class ConfigTest extends TestUtils {
         // should throw BadValue on things that don't parse
         // as durations and sizes
         intercept[ConfigException.BadValue] {
-            conf.getMilliseconds("strings.a")
+            conf.getDuration("strings.a")
         }
 
         intercept[ConfigException.BadValue] {
-            conf.getNanoseconds("strings.a")
+            conf.getDuration("strings.a", NANOSECONDS)
         }
 
         intercept[ConfigException.BadValue] {
@@ -756,18 +756,6 @@ class ConfigTest extends TestUtils {
 
         // should get durations
         def asNanos(secs: Int) = TimeUnit.SECONDS.toNanos(secs)
-        assertEquals(1000L, conf.getMilliseconds("durations.second"))
-        assertEquals(asNanos(1), conf.getNanoseconds("durations.second"))
-        assertEquals(1000L, conf.getMilliseconds("durations.secondAsNumber"))
-        assertEquals(asNanos(1), conf.getNanoseconds("durations.secondAsNumber"))
-        assertEquals(Seq(1000L, 2000L, 3000L, 4000L),
-            conf.getMillisecondsList("durations.secondsList").asScala)
-        assertEquals(Seq(asNanos(1), asNanos(2), asNanos(3), asNanos(4)),
-            conf.getNanosecondsList("durations.secondsList").asScala)
-        assertEquals(500L, conf.getMilliseconds("durations.halfSecond"))
-        assertEquals(4878955355435272204L, conf.getNanoseconds("durations.largeNanos"))
-        assertEquals(4878955355435272204L, conf.getNanoseconds("durations.plusLargeNanos"))
-        assertEquals(-4878955355435272204L, conf.getNanoseconds("durations.minusLargeNanos"))
 
         // get durations as java.time.Duration
         assertEquals(1000L, conf.getDuration("durations.second").toMillis)

--- a/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
@@ -5,15 +5,18 @@ package com.typesafe.config.impl
 
 import org.junit.Assert._
 import org.junit._
+
 import scala.collection.JavaConverters._
 import com.typesafe.config._
 import java.util.{ Collections, TimeZone, TreeSet }
 import java.io.File
+
 import scala.collection.mutable
 import equiv03.SomethingInEquiv03
 import java.io.StringReader
 import java.net.URL
 import java.time.Duration
+import java.util.concurrent.TimeUnit.MILLISECONDS
 
 class PublicApiTest extends TestUtils {
 
@@ -32,7 +35,7 @@ class PublicApiTest extends TestUtils {
         val a = conf.getInt("ints.fortyTwo")
         val child = conf.getConfig("ints")
         val c = child.getInt("fortyTwo")
-        val ms = conf.getMilliseconds("durations.halfSecond")
+        val ms = conf.getDuration("durations.halfSecond", MILLISECONDS)
 
         // should have used system variables
         if (System.getenv("HOME") != null)

--- a/config/src/test/scala/com/typesafe/config/impl/UnitParserTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/UnitParserTest.scala
@@ -10,6 +10,7 @@ import org.junit.Assert._
 import org.junit._
 import com.typesafe.config._
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.{ MILLISECONDS, NANOSECONDS }
 
 class UnitParserTest extends TestUtils {
 
@@ -82,9 +83,9 @@ class UnitParserTest extends TestUtils {
         assertEquals("could get 1d from conf as days",
             1L, conf.getDuration("foo", TimeUnit.DAYS))
         assertEquals("could get 1d from conf as nanos",
-            dayInNanos, conf.getNanoseconds("foo"))
+            dayInNanos, conf.getDuration("foo", NANOSECONDS))
         assertEquals("could get 1d from conf as millis",
-            TimeUnit.DAYS.toMillis(1), conf.getMilliseconds("foo"))
+            TimeUnit.DAYS.toMillis(1), conf.getDuration("foo", MILLISECONDS))
     }
 
     @Test


### PR DESCRIPTION
Aside from this PR, `Config#getMilliseconds()` and `Config#getNanoseconds()` have been marked as deprecated for a while. Makes sense to remove them for next minor release.