### PR TITLE
Add support for constructor handling in config beans

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,9 +482,11 @@ and
 
 ### ConfigBeanFactory
 
-As of version 1.3.0, if you have a Java object that follows
-JavaBean conventions (zero-args constructor, getters and setters),
-you can automatically initialize it from a `Config`.
+You can initialize some class from a `Config`, if a class contains 
+a no-arg constructor, or a public constructor annotated with `java.beans.ConstructorProperties` 
+or a constructor which have a parameter names. The constructor parameter name will be used to 
+lookup the field in the config object. Then will be gathered all bean properties, 
+that have getters and setters and corresponding fields from the config will be injected into them.
 
 Use
 `ConfigBeanFactory.create(config.getConfig("subtree-that-matches-bean"),

--- a/config/src/main/java/com/typesafe/config/impl/ConfigBeanImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigBeanImpl.java
@@ -372,7 +372,7 @@ public class ConfigBeanImpl {
         return getField(beanClass, fieldName);
     }
 
-    private static <T> ConstructorInfo<T> getConstructor(Class beanClass) {
+    private static <T> ConstructorInfo<T> getConstructor(Class<T> beanClass) {
         ConstructorInfo<T> targetConstructor = null;
         Constructor<T> firstPublicConstructor = null;
         boolean single = true;
@@ -393,7 +393,7 @@ public class ConfigBeanImpl {
                 }
             }
         }
-        if (targetConstructor == null && single && firstPublicConstructor.getParameterCount() > 0) {
+        if (targetConstructor == null && single && firstPublicConstructor != null && firstPublicConstructor.getParameterCount() > 0) {
             //If there is only one public constructor with parameters and bean is compiled with `-parameters` argument, try to use it
             List<String> parameters = new ArrayList<>();
             for (Parameter parameter : firstPublicConstructor.getParameters()) {

--- a/config/src/test/java/beanconfig/ConstructorConfig.java
+++ b/config/src/test/java/beanconfig/ConstructorConfig.java
@@ -8,13 +8,15 @@ public class ConstructorConfig {
   private final String foo;
   private final String bar;
   private final NestedConfig nested;
+  private final NestedWithoutAnnotation nestedWithoutAnnotation;
   private String baz;
 
-  @ConstructorProperties({"foo", "bar", "nested"})
-  public ConstructorConfig(String foo, @Optional String bar, NestedConfig nested) {
+  @ConstructorProperties({"foo", "bar", "nested", "nestedWithoutAnnotation"})
+  public ConstructorConfig(String foo, @Optional String bar, NestedConfig nested, NestedWithoutAnnotation nestedWithoutAnnotation) {
     this.foo = foo;
     this.bar = bar;
     this.nested = nested;
+    this.nestedWithoutAnnotation = nestedWithoutAnnotation;
   }
 
   public String getFoo() {
@@ -27,6 +29,10 @@ public class ConstructorConfig {
 
   public NestedConfig getNested() {
     return nested;
+  }
+
+  public NestedWithoutAnnotation getNestedWithoutAnnotation() {
+    return nestedWithoutAnnotation;
   }
 
   public String getBaz() {
@@ -49,4 +55,35 @@ public class ConstructorConfig {
       return foo;
     }
   }
+
+  public static class NestedWithoutAnnotation {
+    private final String foo;
+
+    public NestedWithoutAnnotation(String foo) {
+      this.foo = foo;
+    }
+
+    public String getFoo() {
+      return foo;
+    }
+  }
+
+  public static class ConstructorConfigSkipWithoutAnnotation extends ConstructorConfig {
+
+    @ConstructorProperties({"foo", "bar", "nested", "nestedWithoutAnnotation"})
+    public ConstructorConfigSkipWithoutAnnotation(String foo, @Optional String bar, NestedConfig nested, NestedWithAnnotation nestedWithAnnotation) {
+        super(foo, bar, nested, nestedWithAnnotation);
+    }
+
+  }
+
+  public static class NestedWithAnnotation extends NestedWithoutAnnotation {
+
+      @ConstructorProperties({"foo"})
+      public NestedWithAnnotation(String foo) {
+        super(foo);
+      }
+
+    }
+
 }

--- a/config/src/test/java/beanconfig/ConstructorConfig.java
+++ b/config/src/test/java/beanconfig/ConstructorConfig.java
@@ -1,0 +1,52 @@
+package beanconfig;
+
+import com.typesafe.config.Optional;
+
+import java.beans.ConstructorProperties;
+
+public class ConstructorConfig {
+  private final String foo;
+  private final String bar;
+  private final NestedConfig nested;
+  private String baz;
+
+  @ConstructorProperties({"foo", "bar", "nested"})
+  public ConstructorConfig(String foo, @Optional String bar, NestedConfig nested) {
+    this.foo = foo;
+    this.bar = bar;
+    this.nested = nested;
+  }
+
+  public String getFoo() {
+    return foo;
+  }
+
+  public String getBar() {
+    return bar;
+  }
+
+  public NestedConfig getNested() {
+    return nested;
+  }
+
+  public String getBaz() {
+    return baz;
+  }
+
+  public void setBaz(String baz) {
+    this.baz = baz;
+  }
+
+  public static class NestedConfig {
+    private final String foo;
+
+    @ConstructorProperties({"foo"})
+    public NestedConfig(String foo) {
+      this.foo = foo;
+    }
+
+    public String getFoo() {
+      return foo;
+    }
+  }
+}

--- a/config/src/test/java/beanconfig/ConstructorConfigNoAnnotation.java
+++ b/config/src/test/java/beanconfig/ConstructorConfigNoAnnotation.java
@@ -1,0 +1,37 @@
+package beanconfig;
+
+import com.typesafe.config.Optional;
+
+public class ConstructorConfigNoAnnotation {
+  private final String foo;
+  private final String bar;
+  private final ConstructorConfig.NestedConfig nested;
+  private String baz;
+
+  public ConstructorConfigNoAnnotation(String foo, @Optional String bar, ConstructorConfig.NestedConfig nested) {
+    this.foo = foo;
+    this.bar = bar;
+    this.nested = nested;
+  }
+
+  public String getFoo() {
+    return foo;
+  }
+
+  public String getBar() {
+    return bar;
+  }
+
+  public ConstructorConfig.NestedConfig getNested() {
+    return nested;
+  }
+
+  public String getBaz() {
+    return baz;
+  }
+
+  public void setBaz(String baz) {
+    this.baz = baz;
+  }
+
+}

--- a/config/src/test/java/beanconfig/MultipleConstructorsConfig.java
+++ b/config/src/test/java/beanconfig/MultipleConstructorsConfig.java
@@ -1,0 +1,34 @@
+package beanconfig;
+
+import java.beans.ConstructorProperties;
+
+public class MultipleConstructorsConfig {
+  private String foo;
+  private String bar;
+  private String baz;
+
+  @ConstructorProperties({"foo", "bar"})
+  public MultipleConstructorsConfig(String foo, String bar) {
+    this.foo = foo;
+    this.bar = bar;
+  }
+
+  @ConstructorProperties({"foo", "bar", "baz"})
+  public MultipleConstructorsConfig(String foo, String bar, String baz) {
+    this.foo = foo;
+    this.bar = bar;
+    this.baz = baz;
+  }
+
+  public String getFoo() {
+    return foo;
+  }
+
+  public String getBar() {
+    return bar;
+  }
+
+  public String getBaz() {
+    return baz;
+  }
+}

--- a/config/src/test/java/beanconfig/PrivateConstructorConfig.java
+++ b/config/src/test/java/beanconfig/PrivateConstructorConfig.java
@@ -1,0 +1,19 @@
+package beanconfig;
+
+public class PrivateConstructorConfig {
+  private final String foo;
+  private final String bar;
+
+  private PrivateConstructorConfig(String foo, String bar) {
+    this.foo = foo;
+    this.bar = bar;
+  }
+
+  public String getFoo() {
+    return foo;
+  }
+
+  public String getBar() {
+    return bar;
+  }
+}

--- a/config/src/test/resources/beanconfig/beanconfig01.conf
+++ b/config/src/test/resources/beanconfig/beanconfig01.conf
@@ -128,14 +128,14 @@
         }
       ]
     },
-  "constructor": {
-    "foo": "fooString",
-    "nested": {
-      "foo": "nestedFooString"
-    },
-    "nestedWithoutAnnotation": {
-      "foo": "nestedWithoutAnnotationString"
-    },
-    "baz": "bazString"
-  }
+    "constructor": {
+      "foo": "fooString",
+      "nested": {
+        "foo": "nestedFooString"
+      },
+      "nestedWithoutAnnotation": {
+        "foo": "nestedWithoutAnnotationString"
+      },
+      "baz": "bazString"
+    }
 }

--- a/config/src/test/resources/beanconfig/beanconfig01.conf
+++ b/config/src/test/resources/beanconfig/beanconfig01.conf
@@ -133,6 +133,9 @@
     "nested": {
       "foo": "nestedFooString"
     },
+    "nestedWithoutAnnotation": {
+      "foo": "nestedWithoutAnnotationString"
+    },
     "baz": "bazString"
   }
 }

--- a/config/src/test/resources/beanconfig/beanconfig01.conf
+++ b/config/src/test/resources/beanconfig/beanconfig01.conf
@@ -127,5 +127,12 @@
           yes : "testYesTwo"
         }
       ]
-    }
+    },
+  "constructor": {
+    "foo": "fooString",
+    "nested": {
+      "foo": "nestedFooString"
+    },
+    "baz": "bazString"
+  }
 }

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
@@ -296,6 +296,14 @@ class ConfigBeanFactoryTest extends TestUtils {
     }
 
     @Test
+    def testPrivateConstructor(): Unit = {
+        val e = intercept[ConfigException.BadBean] {
+            ConfigBeanFactory.create(ConfigFactory.empty(), classOf[PrivateConstructorConfig])
+        }
+        assertTrue(e.getMessage.contains("needs a public no-args constructor to be used as a bean"))
+    }
+
+    @Test
     def testMultipleConstructors(): Unit = {
         val e = intercept[ConfigException.BadBean] {
             ConfigBeanFactory.create(ConfigFactory.empty(), classOf[MultipleConstructorsConfig])

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
@@ -3,10 +3,9 @@
  */
 package com.typesafe.config.impl
 
-import beanconfig.EnumsConfig.{ Solution, Problem }
-import com.typesafe.config._
-
-import java.io.{ InputStream, InputStreamReader }
+import beanconfig.EnumsConfig.{Problem, Solution}
+import com.typesafe.config.{ConfigBeanFactory, _}
+import java.io.{InputStream, InputStreamReader}
 import java.time.Duration
 
 import beanconfig._
@@ -277,6 +276,26 @@ class ConfigBeanFactoryTest extends TestUtils {
             ConfigBeanFactory.create(ConfigFactory.empty(), classOf[DifferentFieldNameFromAccessorsConfig])
         }
         assertTrue("only one missing value error", e.getMessage.contains("No setting"))
+    }
+
+    @Test
+    def testConstructor(): Unit = {
+        val bean = ConfigBeanFactory.create(loadConfig().getConfig("constructor"), classOf[ConstructorConfig])
+        val nestedBean = bean.getNested
+
+        assertEquals("foo", "fooString", bean.getFoo)
+        assertNull("bar", bean.getBar)
+        assertNotNull("nested", nestedBean)
+        assertEquals("nestedFooString", nestedBean.getFoo)
+        assertEquals("baz", "bazString", bean.getBaz)
+    }
+
+    @Test
+    def testMultipleConstructors(): Unit = {
+        val e = intercept[ConfigException.BadBean] {
+            ConfigBeanFactory.create(ConfigFactory.empty(), classOf[MultipleConstructorsConfig])
+        }
+        assertTrue("multiple constructors", e.getMessage.contains("needs a single constructor"))
     }
 
     private def loadConfig(): Config = {


### PR DESCRIPTION
Add support for beans, having not default constructor with annotation java.beans.ConstructorProperties. 
This allowing to write bean class using lombok annotation `@Value` instead of `@Data`