### PR TITLE
Fix bug with substitutions in Config.resolveWith

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ResolveSource.java
+++ b/config/src/main/java/com/typesafe/config/impl/ResolveSource.java
@@ -242,9 +242,7 @@ final class ResolveSource {
             if (old == root && replacement instanceof Container) {
                 return new ResolveSource(rootMustBeObj((Container) replacement));
             } else {
-                throw new ConfigException.BugOrBroken("replace in parent not possible " + old + " with " + replacement
-                        + " in " + this);
-                // return this;
+                return this;
             }
         }
     }

--- a/config/src/test/scala/com/typesafe/config/impl/MergeTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/MergeTest.scala
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2012 Typesafe Inc. <http://typesafe.com>
+ */
+package com.typesafe.config.impl
+
+import org.junit.Assert._
+import org.junit._
+import com.typesafe.config.{ConfigFactory, ConfigResolveOptions, ConfigResolver, ConfigValue}
+
+class MergeTest extends TestUtils {
+
+    @Test
+    def mergeSubstitutionWithFallback() {
+        val fallback = parseConfig("a: 123")
+        val conf = parseConfig("b: 234, a: ${b}")
+        val merged = conf
+          .withFallback(fallback)
+          .resolveWith(
+              ConfigFactory.empty(),
+              ConfigResolveOptions.defaults().setAllowUnresolved(true)
+          ).resolve()
+        assertEquals(234, merged.getInt("a"))
+    }
+
+    @Test
+    def mergeSubstitutionWithReplacementsAndFallback() {
+        val replacements = parseConfig("b: 567")
+        val fallback = parseConfig("a: 123, b: 456")
+        val conf = parseConfig("b: 234, a: ${b}")
+        val merged = conf
+          .withFallback(fallback)
+          .resolveWith(
+              replacements,
+              ConfigResolveOptions.defaults().setAllowUnresolved(true)
+          ).resolve()
+        assertEquals(567, merged.getInt("a"))
+    }
+
+    @Test
+    def mergeSubstitutionWithFallbackInChild() {
+        val fallback = parseConfig("a: 123")
+        val conf = parseConfig("b: {d: 234}, a: {c: ${b.d} }")
+        val merged = conf
+          .withFallback(fallback)
+          .resolveWith(
+              ConfigFactory.empty(),
+              ConfigResolveOptions.defaults().setAllowUnresolved(true)
+          ).resolve()
+        assertEquals(234, merged.getInt("a.c"))
+    }
+
+    @Test
+    def mergeSubstitutionFromFallback() {
+        val fallback = parseConfig("a: 123")
+        val conf = parseConfig("b: ${a}")
+        val merged = conf
+          .withFallback(fallback)
+          .resolveWith(
+              ConfigFactory.empty(),
+              ConfigResolveOptions.defaults().setAllowUnresolved(true)
+          ).resolve()
+        assertEquals(123, merged.getInt("a"))
+    }
+
+    @Test
+    def mergeSubstitutionInObjectWithFallback() {
+        val fallback = parseConfig("a: {c: 1, d: 2}")
+        val conf = parseConfig("b: {d: 3, e: 4}, a: ${b}")
+        val merged = conf
+          .withFallback(fallback)
+          .resolveWith(
+              ConfigFactory.empty(),
+              ConfigResolveOptions.defaults().setAllowUnresolved(true)
+          ).resolve()
+        assertEquals(3, merged.getInt("a.d"))
+    }
+}


### PR DESCRIPTION
This is a fix for [Issue 664](https://github.com/lightbend/config/issues/664)

When calling Config.resolveWith on a node with a deferred merge,
in a direct decentant of the root node, an exception would always
be thrown when trying to perform a substitution.

This patch contains several test, most of which previously
failed, as well as a small patch that fixes the problem.

Sadly, my confidence in the patch is a bit on the low side;
I don't fully understand how the ResolveSource class is supposed
to work. I have simply uncommented a "return this" and removed
a throwing of an exception. I'm guessing there might have been a
reason wy that exception was thrown in the first place.
Sadly, the commit which changed this behaviour
(0a20b9ad73da7d9359bfab511db710a18072bd65), seems to be a
from-scratch rewrite of the substitution resolver, so it's
not possible to see in the code why this code changed in
this way.

This patch does not break any additional tests.