### PR TITLE
Fixed 501 error for the maven central link, using of https

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ sbt dependency:
 
 Link for direct download if you don't use a dependency manager:
 
- - http://central.maven.org/maven2/com/typesafe/config/
+ - https://repo1.maven.org/maven2/com/typesafe/config/
 
 ### Release Notes
 


### PR DESCRIPTION
I started to learn the documentation, but get an error on the screenshot.
So, we need to change the documentation for the actual link.

<!--- Why is this change required? What problem does it solve? -->
![image](https://user-images.githubusercontent.com/12239422/73167905-cc84fc80-4109-11ea-86c7-d49178828e1e.png)

> Effective January 15, 2020, The Central Repository no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS.
> 
> If you're receiving this error, then you need to replace all URL references to Maven Central with their canonical HTTPS counterparts:
> 
> Replaced with http://repo1.maven.org/maven2/