### PR TITLE
Allow unquoted strings with underscores

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigImplUtil.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImplUtil.java
@@ -94,7 +94,7 @@ final public class ConfigImplUtil {
         // only unquote if it's pure alphanumeric
         for (int i = 0; i < s.length(); ++i) {
             char c = s.charAt(i);
-            if (!(Character.isLetter(c) || Character.isDigit(c) || c == '-'))
+            if (!(Character.isLetter(c) || Character.isDigit(c) || c == '-' || c == '_'))
                 return renderJsonString(s);
         }
 


### PR DESCRIPTION
Might be a long shot, but I don't believe this modifies the spec and it would be nice for those who prefer underscores over hyphens