### PR TITLE
Fix: Avoid loading all the environment variables as configurations

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
@@ -371,7 +371,7 @@ public class ConfigImpl {
 
     private static AbstractConfigObject loadEnvVariablesOverrides() {
         Map<String, String> env = new HashMap(System.getenv());
-        Map<String, String> result = new HashMap(System.getenv());
+        Map<String, String> result = new HashMap();
 
         for (String key : env.keySet()) {
             if (key.startsWith(ENV_VAR_OVERRIDE_PREFIX)) {

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
@@ -1135,6 +1135,10 @@ class ConfigTest extends TestUtils {
             assertEquals(3, conf02.getInt("a-c"))
             assertEquals(4, conf02.getInt("a_c"))
 
+            intercept[ConfigException.Missing] {
+                conf02.getInt("CONFIG_FORCE_a_b_c")
+            }
+
             assertEquals("foo", conf04.getString("akka.version"))
             assertEquals(10, conf04.getInt("akka.event-handler-dispatcher.max-pool-size"))
         } finally {


### PR DESCRIPTION
This fixes:
https://github.com/playframework/playframework/issues/10206
 and #684 

cc. @GMShuhr and @mkurz