### PR TITLE
Fix the Map spec implementation for ConfigObject.

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
@@ -606,7 +606,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
 
     @Override
     public Set<String> keySet() {
-        return value.keySet();
+        return Collections.unmodifiableSet(value.keySet());
     }
 
     @Override
@@ -624,7 +624,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
                     e.getKey(), e
                     .getValue()));
         }
-        return entries;
+        return Collections.unmodifiableSet(entries);
     }
 
     @Override
@@ -639,7 +639,7 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
 
     @Override
     public Collection<ConfigValue> values() {
-        return new HashSet<ConfigValue>(value.values());
+        return Collections.unmodifiableCollection(value.values());
     }
 
     final private static String EMPTY_NAME = "empty config";


### PR DESCRIPTION
According to the Map specification, methods keySet, values and entrySet are backed by the map, so changes to the map are reflected in the collection, and vice-versa. ConfigObject interface extends Map, so it must conform the specification. Also, ConfigObject declared as immutable, so keySet, values and entrySet must return immutable collections.