### PR TITLE
Merge objects before resolve

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,8 @@ more revision will likely be needed.
 # Making a release
 
 See RELEASING.md
+
+# Running the single test you're working on
+
+I tend to forget this sbt syntax, in the sbt shell:
+`testOnly -- -Dconfig.trace=substitutions --tests=nameOfTestMethod`

--- a/config/src/main/java/com/typesafe/config/impl/ConfigReference.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigReference.java
@@ -11,8 +11,7 @@ import com.typesafe.config.ConfigValue;
 import com.typesafe.config.ConfigValueType;
 
 /**
- * ConfigReference replaces ConfigReference (the older class kept for back
- * compat) and represents the ${} substitution syntax. It can resolve to any
+ * ConfigReference represents the ${} substitution syntax. It can resolve to any
  * kind of value.
  */
 final class ConfigReference extends AbstractConfigValue implements Unmergeable {

--- a/config/src/main/java/com/typesafe/config/impl/Unmergeable.java
+++ b/config/src/main/java/com/typesafe/config/impl/Unmergeable.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 /**
  * Interface that tags a ConfigValue that is not mergeable until after
  * substitutions are resolved. Basically these are special ConfigValue that
- * never appear in a resolved tree, like {@link ConfigSubstitution} and
+ * never appear in a resolved tree, like {@link ConfigReference} and
  * {@link ConfigDelayedMerge}.
  */
 interface Unmergeable {


### PR DESCRIPTION
This is an alternate fix for #599 ... maybe still a bit of a hack.

Previously, if we had something like this:

 foo : ""
 foo : { bar : ${undefined} }
 foo : { bar : 42 }

Then it was possible to end up with the value of foo as a delayed merge with
multiple adjacent objects in its stack.

We then would resolve each value in the stack, and only after that
merge all the values. But we need to merge objects BEFORE we try to
resolve them, in case some of the unresolved substitutions just
go away.

This was only happening with the bottom of the stack as a non-object,
since if the bottom was an object, we were merging the objects
as we went along anyway.