### PR TITLE
Correct reference to package description anchor link

### DIFF
--- a/config/src/main/java/com/typesafe/config/Config.java
+++ b/config/src/main/java/com/typesafe/config/Config.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
  * You can find an example app and library <a
  * href="https://github.com/lightbend/config/tree/master/examples">on
  * GitHub</a>. Also be sure to read the <a
- * href="package-summary.html#package_description">package overview</a> which
+ * href="package-summary.html#package.description">package overview</a> which
  * describes the big picture as shown in those examples.
  * 
  * <p>

--- a/config/src/main/java/com/typesafe/config/ConfigFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigFactory.java
@@ -30,7 +30,7 @@ import java.util.concurrent.Callable;
  * <p> You can find an example app and library <a
  * href="https://github.com/lightbend/config/tree/master/examples">on
  * GitHub</a>.  Also be sure to read the <a
- * href="package-summary.html#package_description">package
+ * href="package-summary.html#package.description">package
  * overview</a> which describes the big picture as shown in those
  * examples.
  */


### PR DESCRIPTION
The anchor link for the package description of the `com.typesafe.config` package
as seen in the hosted version of the API documentation [[1]] is `package.description`
not `package_description`.

Correct the references to the anchor link.

[1]: https://lightbend.github.io/config/latest/api/com/typesafe/config/package-summary.html