### PR TITLE
use correct ParseOptions object

### DIFF
--- a/config/src/main/java/com/typesafe/config/ConfigFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigFactory.java
@@ -82,14 +82,14 @@ public final class ConfigFactory {
     /**
      * Like {@link #load(String)} but uses the supplied class loader instead of
      * the current thread's context class loader.
-     * 
+     *
      * <p>
      * To load a standalone resource (without the default reference and default
      * overrides), use {@link #parseResourcesAnySyntax(ClassLoader, String)}
      * rather than this method. To load only the reference config use
      * {@link #defaultReference(ClassLoader)} and to load only the overrides use
      * {@link #defaultOverrides(ClassLoader)}.
-     * 
+     *
      * @param loader class loader to look for resources in
      * @param resourceBasename basename (no .conf/.json/.properties suffix)
      * @return configuration for an application relative to given class loader
@@ -333,27 +333,27 @@ public final class ConfigFactory {
      * by merging all resources "reference.conf" found on the classpath and
      * overriding the result with system properties. The returned reference
      * configuration will already have substitutions resolved.
-     * 
+     *
      * <p>
      * Libraries and frameworks should ship with a "reference.conf" in their
      * jar.
-     * 
+     *
      * <p>
      * The reference config must be looked up in the class loader that contains
      * the libraries that you want to use with this config, so the
      * "reference.conf" for each library can be found. Use
      * {@link #defaultReference(ClassLoader)} if the context class loader is not
      * suitable.
-     * 
+     *
      * <p>
      * The {@link #load()} methods merge this configuration for you
      * automatically.
-     * 
+     *
      * <p>
      * Future versions may look for reference configuration in more places. It
      * is not guaranteed that this method <em>only</em> looks at
      * "reference.conf".
-     * 
+     *
      * @return the default reference config for context class loader
      */
     public static Config defaultReference() {
@@ -613,7 +613,7 @@ public final class ConfigFactory {
      * used to override configuration keys.
      * Environment variables taken in considerations are starting with
      * {@code CONFIG_FORCE_}
-     * 
+     *
      * <p>
      * Environment variables are mangled in the following way after stripping the prefix "CONFIG_FORCE_":
      * <table border="1">
@@ -634,11 +634,11 @@ public final class ConfigFactory {
      *     <td>_ [underscore]</td>
      * </tr>
      * </table>
-     * 
+     *
      * <p>
      * A variable like: {@code CONFIG_FORCE_a_b__c___d}
      * is translated to a config key: {@code a.b-c_d}
-     * 
+     *
      * <p>
      * This method can return a global immutable singleton, so it's preferred
      * over parsing system properties yourself.
@@ -1129,8 +1129,8 @@ public final class ConfigFactory {
      * if none was specified.
      */
     public static java.util.Optional<Config> parseApplicationReplacement(ConfigParseOptions parseOptions) {
-        ensureClassLoader(parseOptions, "parseApplicationReplacement");
-        ClassLoader loader = parseOptions.getClassLoader();
+        final ConfigParseOptions withLoader = ensureClassLoader(parseOptions, "parseApplicationReplacement");
+        ClassLoader loader = withLoader.getClassLoader();
 
         int specified = 0;
 


### PR DESCRIPTION
https://github.com/lightbend/config/pull/708 has an issue with calling `ensureClassLoader` but not using the result, this PR fixes that.

Note: I'm not sure where the formatting fixes came from, could that be from `sbt test`? I ran that locally.  I can get rid of them if needed.