### PR TITLE
Add the possibility to configure the CONFIG_FORCE_ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,8 +681,13 @@ With this option enabled only environment variables starting with
   - double underscore(`__`) is converted into a dash(`-`)
   - triple underscore(`___`) is converted into a single underscore(`_`)
 
-i.e. The environment variable `CONFIG_FORCE_a_b__c___d` set the
-configuration key `a.b-c_d`
+i.e. The environment variable `CONFIG_FORCE_a_b__c___d` sets the
+configuration key `a.b-c_d`.
+
+The `CONFIG_FORCE_` prefix can be customized if needed: the JVM
+property `-Dconfig.override_with_env_vars_prefix=<CUSTOM_PREFIX>`
+will set it equal to `<CUSTOM_PREFIX>`. All other mangling rules
+still apply.
 
 ### Set array values outside configuration files
 
@@ -781,7 +786,7 @@ If you have trouble with your configuration, some useful tips.
    Play/Akka 2.0.
  - Use `myConfig.root().render()` to get a `Config` as a
    string with comments showing where each value came from.
-   This string can be printed out on console or logged to 
+   This string can be printed out on console or logged to
    a file etc.
  - If you see errors like
    `com.typesafe.config.ConfigException$Missing: No configuration setting found for key foo`,
@@ -940,7 +945,7 @@ format.
 
 The license is Apache 2.0, see LICENSE-2.0.txt.
 
-## Maintained by 
+## Maintained by
 
 This project is maintained mostly by [@havocp](https://github.com/havocp) and [@akka-team](https://github.com/orgs/lightbend/teams/akka-team/members).
 

--- a/README.md
+++ b/README.md
@@ -682,7 +682,8 @@ With this option enabled only environment variables starting with
   - triple underscore(`___`) is converted into a single underscore(`_`)
 
 i.e. The environment variable `CONFIG_FORCE_a_b__c___d` sets the
-configuration key `a.b-c_d`.
+configuration key `a.b-c_d` (NOTE: keys are case-sensitive, so
+`CONFIG_FORCE_ab` is different from `CONFIG_FORCE_AB`.
 
 The `CONFIG_FORCE_` prefix can be customized if needed: the JVM
 property `-Dconfig.override_with_env_vars_prefix=<CUSTOM_PREFIX>`

--- a/build.sbt
+++ b/build.sbt
@@ -92,6 +92,7 @@ lazy val configLib =  Project("config", file("config"))
       "CONFIG_FORCE_testList_1" -> "11",
       "CONFIG_FORCE_42___a" -> "1",
       "CONFIG_FORCE_a_b_c" -> "2",
+      "CUSTOM_PREFIX_a_b_c" -> "200",
       "CONFIG_FORCE_a__c" -> "3",
       "CONFIG_FORCE_a___c" -> "4",
       "CONFIG_FORCE_akka_version" -> "foo",

--- a/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
@@ -32,7 +32,8 @@ import com.typesafe.config.impl.SimpleIncluder.NameSource;
  * For use only by the {@link com.typesafe.config} package.
  */
 public class ConfigImpl {
-    private static final String ENV_VAR_OVERRIDE_PREFIX = "CONFIG_FORCE_";
+    private static final String ENV_VAR_OVERRIDE_PREFIX_PROPERTY_NAME = "config.override_with_env_vars_prefix";
+    private static final String ENV_VAR_OVERRIDE_DEFAULT_PREFIX = "CONFIG_FORCE_";
 
     private static class LoaderCache {
         private Config currentSystemProperties;
@@ -373,9 +374,12 @@ public class ConfigImpl {
         Map<String, String> env = new HashMap(System.getenv());
         Map<String, String> result = new HashMap();
 
+        String customPrefix = System.getProperty(ENV_VAR_OVERRIDE_PREFIX_PROPERTY_NAME);
+        String prefix = customPrefix != null ? customPrefix : ENV_VAR_OVERRIDE_DEFAULT_PREFIX;
+
         for (String key : env.keySet()) {
-            if (key.startsWith(ENV_VAR_OVERRIDE_PREFIX)) {
-                result.put(ConfigImplUtil.envVariableAsProperty(key, ENV_VAR_OVERRIDE_PREFIX), env.get(key));
+            if (key.startsWith(prefix)) {
+                result.put(ConfigImplUtil.envVariableAsProperty(key, prefix), env.get(key));
             }
         }
 


### PR DESCRIPTION
## Description

When using `config.override_with_env_vars`, the library looks for env variables that are prefixed with `CONFIG_FORCE_`. Some applications may prefer to set a custom prefix instead, so this commit adds the possibility to customize it using the `config.override_with_env_vars_prefix` JVM variable.

[Related issue](https://github.com/lightbend/config/issues/718).

## What's left

I'd like to add some tests but for some reason some tests are failing locally (I've tried them before changing anything and they were still failing).

In particular, the `ConfigTest:testLoadWithEnvSubstitutions` is failing, which is the test I think I should use as reference to write a new test. The error is

```
java.lang.AssertionError: 
Expected :1
Actual   :42

	at org.junit.Assert.failNotEquals(Assert.java:743)
	at com.typesafe.config.impl.ConfigTest.testLoadWithEnvSubstitutions(ConfigTest.scala:1133)
```

Is there some test setup which is expected before running tests?

## Other comments

I have noticed that the algorithm that matches environment variables with properties is case-sensitive, so `CONFIG_FORCE_WHATEVER` will not replace a property called `whatever`. I understand that it depends on the fact that `whatever` and `WHATEVER` are in fact different properties but I still think it's a little unexpected (at least coming from Spring).

Should this behavior be stated more clearly in the documentation?