### PR TITLE
Expose the AST/CST for interation. Fixes #300

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/AbstractConfigNode.java
+++ b/config/src/main/java/com/typesafe/config/impl/AbstractConfigNode.java
@@ -3,11 +3,14 @@
  */
 package com.typesafe.config.impl;
 
-import com.typesafe.config.parser.ConfigNode;
 import java.util.Collection;
+
+import com.typesafe.config.ConfigOrigin;
+import com.typesafe.config.parser.ConfigNode;
 
 abstract class AbstractConfigNode implements ConfigNode {
     abstract Collection<Token> tokens();
+
     final public String render() {
         StringBuilder origText = new StringBuilder();
         Iterable<Token> tokens = tokens();
@@ -19,11 +22,20 @@ abstract class AbstractConfigNode implements ConfigNode {
 
     @Override
     final public boolean equals(Object other) {
-        return other instanceof AbstractConfigNode && render().equals(((AbstractConfigNode)other).render());
+        return other instanceof AbstractConfigNode && render().equals(((AbstractConfigNode) other).render());
     }
 
     @Override
     final public int hashCode() {
         return render().hashCode();
+    }
+
+    @Override
+    public ConfigOrigin origin() {
+        Collection<Token> tok = tokens();
+        if (tok.isEmpty())
+            return null;
+        else
+            return tok.iterator().next().origin();
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigBoolean.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigBoolean.java
@@ -8,8 +8,10 @@ import java.io.Serializable;
 
 import com.typesafe.config.ConfigOrigin;
 import com.typesafe.config.ConfigValueType;
+import com.typesafe.config.parser.ConfigNodeBoolean;
+import com.typesafe.config.parser.ConfigNodeVisitor;
 
-final class ConfigBoolean extends AbstractConfigValue implements Serializable {
+final class ConfigBoolean extends AbstractConfigValue implements Serializable, ConfigNodeBoolean {
 
     private static final long serialVersionUID = 2L;
 
@@ -43,5 +45,15 @@ final class ConfigBoolean extends AbstractConfigValue implements Serializable {
     // serialization all goes through SerializedConfigValue
     private Object writeReplace() throws ObjectStreamException {
         return new SerializedConfigValue(this);
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitBoolean(this);
+    }
+
+    @Override
+    public boolean getValue() {
+        return value;
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigDocumentParser.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigDocumentParser.java
@@ -258,7 +258,7 @@ final class ConfigDocumentParser {
             return v;
         }
 
-        private ConfigNodePath parseKey(Token token) {
+        private ConfigNodeParsedPath parseKey(Token token) {
             if (flavor == ConfigSyntax.JSON) {
                 if (Tokens.isValueWithType(token, ConfigValueType.STRING)) {
                     return PathParser.parsePathNodeExpression(Collections.singletonList(token).iterator(),
@@ -447,7 +447,7 @@ final class ConfigDocumentParser {
                 } else {
                     keyValueNodes = new ArrayList<AbstractConfigNode>();
                     Token keyToken = t;
-                    ConfigNodePath path = parseKey(keyToken);
+                    ConfigNodeParsedPath path = parseKey(keyToken);
                     keyValueNodes.add(path);
                     Token afterKey = nextTokenCollectingWhitespace(keyValueNodes);
                     boolean insideEquals = false;

--- a/config/src/main/java/com/typesafe/config/impl/ConfigDouble.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigDouble.java
@@ -8,8 +8,10 @@ import java.io.Serializable;
 
 import com.typesafe.config.ConfigOrigin;
 import com.typesafe.config.ConfigValueType;
+import com.typesafe.config.parser.ConfigNodeDouble;
+import com.typesafe.config.parser.ConfigNodeVisitor;
 
-final class ConfigDouble extends ConfigNumber implements Serializable {
+final class ConfigDouble extends ConfigNumber implements Serializable, ConfigNodeDouble {
 
     private static final long serialVersionUID = 2L;
 
@@ -57,5 +59,15 @@ final class ConfigDouble extends ConfigNumber implements Serializable {
     // serialization all goes through SerializedConfigValue
     private Object writeReplace() throws ObjectStreamException {
         return new SerializedConfigValue(this);
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitDouble(this);
+    }
+
+    @Override
+    public double getValue() {
+        return value;
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigInt.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigInt.java
@@ -8,8 +8,10 @@ import java.io.Serializable;
 
 import com.typesafe.config.ConfigOrigin;
 import com.typesafe.config.ConfigValueType;
+import com.typesafe.config.parser.ConfigNodeInt;
+import com.typesafe.config.parser.ConfigNodeVisitor;
 
-final class ConfigInt extends ConfigNumber implements Serializable {
+final class ConfigInt extends ConfigNumber implements Serializable, ConfigNodeInt {
 
     private static final long serialVersionUID = 2L;
 
@@ -57,5 +59,15 @@ final class ConfigInt extends ConfigNumber implements Serializable {
     // serialization all goes through SerializedConfigValue
     private Object writeReplace() throws ObjectStreamException {
         return new SerializedConfigValue(this);
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitInt(this);
+    }
+
+    @Override
+    public int getValue() {
+        return value;
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigLong.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigLong.java
@@ -8,8 +8,10 @@ import java.io.Serializable;
 
 import com.typesafe.config.ConfigOrigin;
 import com.typesafe.config.ConfigValueType;
+import com.typesafe.config.parser.ConfigNodeLong;
+import com.typesafe.config.parser.ConfigNodeVisitor;
 
-final class ConfigLong extends ConfigNumber implements Serializable {
+final class ConfigLong extends ConfigNumber implements Serializable, ConfigNodeLong {
 
     private static final long serialVersionUID = 2L;
 
@@ -57,5 +59,15 @@ final class ConfigLong extends ConfigNumber implements Serializable {
     // serialization all goes through SerializedConfigValue
     private Object writeReplace() throws ObjectStreamException {
         return new SerializedConfigValue(this);
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitLong(this);
+    }
+
+    @Override
+    public long getValue() {
+        return value;
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeArray.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeArray.java
@@ -2,7 +2,9 @@ package com.typesafe.config.impl;
 
 import java.util.Collection;
 
-final class ConfigNodeArray extends ConfigNodeComplexValue {
+import com.typesafe.config.parser.ConfigNodeVisitor;
+
+final class ConfigNodeArray extends ConfigNodeComplexValue implements com.typesafe.config.parser.ConfigNodeArray {
     ConfigNodeArray(Collection<AbstractConfigNode> children) {
         super(children);
     }
@@ -10,5 +12,10 @@ final class ConfigNodeArray extends ConfigNodeComplexValue {
     @Override
     protected ConfigNodeArray newNode(Collection<AbstractConfigNode> nodes) {
         return new ConfigNodeArray(nodes);
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitArray(this);
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeComment.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeComment.java
@@ -1,9 +1,9 @@
 package com.typesafe.config.impl;
 
-
 import com.typesafe.config.ConfigException;
+import com.typesafe.config.parser.ConfigNodeVisitor;
 
-final class ConfigNodeComment extends ConfigNodeSingleToken {
+final class ConfigNodeComment extends ConfigNodeSingleToken implements com.typesafe.config.parser.ConfigNodeComment {
     ConfigNodeComment(Token comment) {
         super(comment);
         if (!Tokens.isComment(super.token)) {
@@ -13,5 +13,15 @@ final class ConfigNodeComment extends ConfigNodeSingleToken {
 
     protected String commentText() {
         return Tokens.getCommentText(super.token);
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitComment(this);
+    }
+
+    @Override
+    public String getValue() {
+        return commentText();
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeComplexValue.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeComplexValue.java
@@ -5,6 +5,8 @@ package com.typesafe.config.impl;
 
 import java.util.*;
 
+import com.typesafe.config.parser.ConfigNode;
+
 abstract class ConfigNodeComplexValue extends AbstractConfigNodeValue {
     final protected ArrayList<AbstractConfigNode> children;
 
@@ -49,4 +51,8 @@ abstract class ConfigNodeComplexValue extends AbstractConfigNodeValue {
     // for use in the indentText() method so we can avoid a gross if/else statement
     // checking the type of this
     abstract ConfigNodeComplexValue newNode(Collection<AbstractConfigNode> nodes);
+
+    public List<ConfigNode> getChildren() {
+        return Collections.unmodifiableList(children);
+    }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeConcatenation.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeConcatenation.java
@@ -2,7 +2,10 @@ package com.typesafe.config.impl;
 
 import java.util.Collection;
 
-final class ConfigNodeConcatenation extends ConfigNodeComplexValue {
+import com.typesafe.config.parser.ConfigNodeVisitor;
+
+final class ConfigNodeConcatenation extends ConfigNodeComplexValue
+        implements com.typesafe.config.parser.ConfigNodeConcatenation {
     ConfigNodeConcatenation(Collection<AbstractConfigNode> children) {
         super(children);
     }
@@ -11,4 +14,10 @@ final class ConfigNodeConcatenation extends ConfigNodeComplexValue {
     protected ConfigNodeConcatenation newNode(Collection<AbstractConfigNode> nodes) {
         return new ConfigNodeConcatenation(nodes);
     }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitConcatenation(this);
+    }
+
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeField.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeField.java
@@ -3,13 +3,16 @@
  */
 package com.typesafe.config.impl;
 
-import com.typesafe.config.ConfigException;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-final class ConfigNodeField extends AbstractConfigNode {
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.parser.ConfigNode;
+import com.typesafe.config.parser.ConfigNodePath;
+import com.typesafe.config.parser.ConfigNodeVisitor;
+
+final class ConfigNodeField extends AbstractConfigNode implements com.typesafe.config.parser.ConfigNodeField {
     final private ArrayList<AbstractConfigNode> children;
 
     public ConfigNodeField(Collection<AbstractConfigNode> children) {
@@ -45,10 +48,10 @@ final class ConfigNodeField extends AbstractConfigNode {
         throw new ConfigException.BugOrBroken("Field node doesn't have a value");
     }
 
-    public ConfigNodePath path() {
+    public ConfigNodeParsedPath path() {
         for (int i = 0; i < children.size(); i++) {
-            if (children.get(i) instanceof ConfigNodePath) {
-                return (ConfigNodePath)children.get(i);
+            if (children.get(i) instanceof ConfigNodeParsedPath) {
+                return (ConfigNodeParsedPath)children.get(i);
             }
         }
         throw new ConfigException.BugOrBroken("Field node doesn't have a path");
@@ -74,5 +77,20 @@ final class ConfigNodeField extends AbstractConfigNode {
             }
         }
         return comments;
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitField(this);
+    }
+
+    @Override
+    public ConfigNodePath getPath() {
+        return path().toUnparsed(origin());
+    }
+
+    @Override
+    public ConfigNode getValue() {
+        return value();
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeInclude.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeInclude.java
@@ -2,8 +2,13 @@ package com.typesafe.config.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
-final class ConfigNodeInclude extends AbstractConfigNode {
+import com.typesafe.config.parser.ConfigNode;
+import com.typesafe.config.parser.ConfigNodeVisitor;
+
+final class ConfigNodeInclude extends AbstractConfigNode implements com.typesafe.config.parser.ConfigNodeInclude {
     final private ArrayList<AbstractConfigNode> children;
     final private ConfigIncludeKind kind;
     final private boolean isRequired;
@@ -42,5 +47,15 @@ final class ConfigNodeInclude extends AbstractConfigNode {
             }
         }
         return null;
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitInclude(this);
+    }
+
+    @Override
+    public List<ConfigNode> getChildren() {
+        return Collections.unmodifiableList(children);
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeParsedPath.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeParsedPath.java
@@ -5,6 +5,7 @@ package com.typesafe.config.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 import com.typesafe.config.ConfigException;
@@ -55,7 +56,7 @@ final class ConfigNodeParsedPath extends AbstractConfigNode {
 
     public ConfigNodeUnparsedPath toUnparsed(ConfigOrigin origin) {
         return new ConfigNodeUnparsedPath(
-                tokens.stream().map(tok -> new ConfigNodeSingleToken(tok)).collect(Collectors.toUnmodifiableList()),
+                Collections.unmodifiableList(tokens.stream().map(tok -> new ConfigNodeSingleToken(tok)).collect(Collectors.toList())),
                 origin);
     }
 

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeParsedPath.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeParsedPath.java
@@ -3,15 +3,18 @@
  */
 package com.typesafe.config.impl;
 
-import com.typesafe.config.ConfigException;
-
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
-final class ConfigNodePath extends AbstractConfigNode {
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigOrigin;
+import com.typesafe.config.parser.ConfigNodeVisitor;
+
+final class ConfigNodeParsedPath extends AbstractConfigNode {
     final private Path path;
     final ArrayList<Token> tokens;
-    ConfigNodePath(Path path, Collection<Token> tokens) {
+    ConfigNodeParsedPath(Path path, Collection<Token> tokens) {
         this.path = path;
         this.tokens = new ArrayList<Token>(tokens);
     }
@@ -25,7 +28,7 @@ final class ConfigNodePath extends AbstractConfigNode {
         return path;
     }
 
-    protected ConfigNodePath subPath(int toRemove) {
+    protected ConfigNodeParsedPath subPath(int toRemove) {
         int periodCount = 0;
         ArrayList<Token> tokensCopy = new ArrayList<Token>(tokens);
         for (int i = 0; i < tokensCopy.size(); i++) {
@@ -34,19 +37,30 @@ final class ConfigNodePath extends AbstractConfigNode {
                 periodCount++;
 
             if (periodCount == toRemove) {
-                return new ConfigNodePath(path.subPath(toRemove), tokensCopy.subList(i + 1, tokensCopy.size()));
+                return new ConfigNodeParsedPath(path.subPath(toRemove), tokensCopy.subList(i + 1, tokensCopy.size()));
             }
         }
         throw new ConfigException.BugOrBroken("Tried to remove too many elements from a Path node");
     }
 
-    protected ConfigNodePath first() {
+    protected ConfigNodeParsedPath first() {
         ArrayList<Token> tokensCopy = new ArrayList<Token>(tokens);
         for (int i = 0; i < tokensCopy.size(); i++) {
             if (Tokens.isUnquotedText(tokensCopy.get(i)) &&
                     tokensCopy.get(i).tokenText().equals("."))
-                return new ConfigNodePath(path.subPath(0, 1), tokensCopy.subList(0, i));
+                return new ConfigNodeParsedPath(path.subPath(0, 1), tokensCopy.subList(0, i));
         }
         return this;
+    }
+
+    public ConfigNodeUnparsedPath toUnparsed(ConfigOrigin origin) {
+        return new ConfigNodeUnparsedPath(
+                tokens.stream().map(tok -> new ConfigNodeSingleToken(tok)).collect(Collectors.toUnmodifiableList()),
+                origin);
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitPath(toUnparsed(null));
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeReference.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeReference.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.impl;
+
+import java.util.List;
+
+import com.typesafe.config.ConfigOrigin;
+import com.typesafe.config.parser.*;
+import com.typesafe.config.parser.ConfigNodePath;
+
+// This is a "virtual" AST node that is synthesized from ConfigNodeSimpleValue to improve traversability of the AST
+final class ConfigNodeReference implements com.typesafe.config.parser.ConfigNodeReference {
+
+    private boolean optional;
+    private List<ConfigNodeSyntax> path;
+    private ConfigOrigin origin;
+
+    ConfigNodeReference(ConfigOrigin origin, List<ConfigNodeSyntax> collect, boolean optional) {
+        this.optional = optional;
+        this.path = collect;
+        this.origin = origin;
+    }
+
+    @Override
+    public String render() {
+        return "${" + (this.optional ? "?" : "")
+                + Tokenizer.render(this.path.stream().map(x -> ((ConfigNodeSingleToken) x).token()).iterator()) + "}";
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitReference(this);
+    }
+
+    @Override
+    public ConfigNodePath getPath() {
+        return new ConfigNodeUnparsedPath(path, origin);
+    }
+
+    @Override
+    public boolean isOptional() {
+        return optional;
+    }
+
+    @Override
+    public ConfigOrigin origin() {
+        return origin;
+    }
+}

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeRoot.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeRoot.java
@@ -1,13 +1,14 @@
 package com.typesafe.config.impl;
 
+import java.util.*;
+
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigOrigin;
 import com.typesafe.config.ConfigSyntax;
+import com.typesafe.config.parser.ConfigNode;
+import com.typesafe.config.parser.ConfigNodeVisitor;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
-final class ConfigNodeRoot extends ConfigNodeComplexValue {
+final class ConfigNodeRoot extends ConfigNodeComplexValue implements com.typesafe.config.parser.ConfigNodeRoot {
     final private ConfigOrigin origin;
 
     ConfigNodeRoot(Collection<AbstractConfigNode> children, ConfigOrigin origin) {
@@ -27,6 +28,11 @@ final class ConfigNodeRoot extends ConfigNodeComplexValue {
             }
         }
         throw new ConfigException.BugOrBroken("ConfigNodeRoot did not contain a value");
+    }
+
+    @Override
+    public List<ConfigNode> getChildren() {
+        return Collections.singletonList(value());
     }
 
     protected ConfigNodeRoot setValue(String desiredPath, AbstractConfigNodeValue value, ConfigSyntax flavor) {
@@ -63,5 +69,10 @@ final class ConfigNodeRoot extends ConfigNodeComplexValue {
             }
         }
         throw new ConfigException.BugOrBroken("ConfigNodeRoot did not contain a value");
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitRoot(this);
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeSimpleValue.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeSimpleValue.java
@@ -48,7 +48,7 @@ final class ConfigNodeSimpleValue extends AbstractConfigNodeValue {
             boolean optional = Tokens.getSubstitutionOptional(token);
 
             return visitor.visitReference(new ConfigNodeReference(token.origin(),
-                    expression.stream().map(x -> new ConfigNodeSingleToken(x)).collect(Collectors.toUnmodifiableList()),
+                    Collections.unmodifiableList(expression.stream().map(x -> new ConfigNodeSingleToken(x)).collect(Collectors.toList())),
                     optional));
         }
         throw new ConfigException.BugOrBroken("ConfigNodeSimpleValue did not contain a valid value token");

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeSingleToken.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeSingleToken.java
@@ -6,8 +6,13 @@ package com.typesafe.config.impl;
 import java.util.Collection;
 import java.util.Collections;
 
-class ConfigNodeSingleToken extends AbstractConfigNode {
+import com.typesafe.config.parser.ConfigNode;
+import com.typesafe.config.parser.ConfigNodeSyntax;
+import com.typesafe.config.parser.ConfigNodeVisitor;
+
+class ConfigNodeSingleToken extends AbstractConfigNode implements ConfigNodeSyntax {
     final Token token;
+
     ConfigNodeSingleToken(Token t) {
         token = t;
     }
@@ -17,5 +22,28 @@ class ConfigNodeSingleToken extends AbstractConfigNode {
         return Collections.singletonList(token);
     }
 
-    protected Token token() { return token; }
+    protected Token token() {
+        return token;
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        if (visitor.includeSyntax())
+            return visitor.visitSyntax(this);
+        else
+            return null;
+    }
+
+    @Override
+    public String getText() {
+        return token.tokenText();
+    }
+
+    @Override
+    public ConfigNode getAnyValue() {
+        if (Tokens.isValue(token))
+            return (ConfigNode) Tokens.getValue(token);
+        else
+            return null;
+    }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNodeUnparsedPath.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNodeUnparsedPath.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.impl;
+
+import java.util.List;
+
+import com.typesafe.config.ConfigOrigin;
+import com.typesafe.config.parser.ConfigNodePath;
+import com.typesafe.config.parser.ConfigNodeSyntax;
+import com.typesafe.config.parser.ConfigNodeVisitor;
+
+// This is the public AST node for. for the internal node, see ConfigNodeParsedPath 
+final class ConfigNodeUnparsedPath implements ConfigNodePath {
+    private List<ConfigNodeSyntax> path;
+    private ConfigOrigin origin;
+
+    ConfigNodeUnparsedPath(List<ConfigNodeSyntax> path, ConfigOrigin origin) {
+        this.path = path;
+        this.origin = origin;
+    }
+
+    @Override
+    public String render() {
+        return toPath().render();
+    }
+
+    @Override
+    public String toString() {
+        return render();
+    }
+
+    private Path toPath() {
+        // Note: we don't eagerly parse the path in case it has errors and the user
+        // wants to fix them via updateSyntax
+        return PathParser.parsePathExpression(path.stream().map(x -> ((ConfigNodeSingleToken) x).token()).iterator(),
+                origin);
+    }
+
+    @Override
+    public List<String> toList() {
+        return toPath().toUnmodifiableJava();
+    }
+
+    @Override
+    public List<ConfigNodeSyntax> getSyntaxNodes() {
+        return path;
+    }
+
+    @Override
+    public ConfigOrigin origin() {
+        return origin;
+    }
+
+    @Override
+    public ConfigNodePath updateSyntax(List<ConfigNodeSyntax> nodes) {
+        return new ConfigNodeUnparsedPath(nodes, origin);
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitPath(this);
+    }
+
+}

--- a/config/src/main/java/com/typesafe/config/impl/ConfigNull.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigNull.java
@@ -9,6 +9,8 @@ import java.io.Serializable;
 import com.typesafe.config.ConfigOrigin;
 import com.typesafe.config.ConfigRenderOptions;
 import com.typesafe.config.ConfigValueType;
+import com.typesafe.config.parser.ConfigNodeNull;
+import com.typesafe.config.parser.ConfigNodeVisitor;
 
 /**
  * This exists because sometimes null is not the same as missing. Specifically,
@@ -18,7 +20,7 @@ import com.typesafe.config.ConfigValueType;
  * not.
  *
  */
-final class ConfigNull extends AbstractConfigValue implements Serializable {
+final class ConfigNull extends AbstractConfigValue implements Serializable, ConfigNodeNull {
 
     private static final long serialVersionUID = 2L;
 
@@ -54,5 +56,10 @@ final class ConfigNull extends AbstractConfigValue implements Serializable {
     // serialization all goes through SerializedConfigValue
     private Object writeReplace() throws ObjectStreamException {
         return new SerializedConfigValue(this);
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitNull(this);
     }
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigString.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigString.java
@@ -9,8 +9,10 @@ import java.io.Serializable;
 import com.typesafe.config.ConfigOrigin;
 import com.typesafe.config.ConfigRenderOptions;
 import com.typesafe.config.ConfigValueType;
+import com.typesafe.config.parser.ConfigNodeString;
+import com.typesafe.config.parser.ConfigNodeVisitor;
 
-abstract class ConfigString extends AbstractConfigValue implements Serializable {
+abstract class ConfigString extends AbstractConfigValue implements Serializable, ConfigNodeString{
 
     private static final long serialVersionUID = 2L;
 
@@ -75,6 +77,16 @@ abstract class ConfigString extends AbstractConfigValue implements Serializable 
 
     @Override
     String transformToString() {
+        return value;
+    }
+
+    @Override
+    public <T> T accept(ConfigNodeVisitor<T> visitor) {
+        return visitor.visitString(this);
+    }
+
+    @Override
+    public String getValue() {
         return value;
     }
 

--- a/config/src/main/java/com/typesafe/config/impl/Path.java
+++ b/config/src/main/java/com/typesafe/config/impl/Path.java
@@ -229,4 +229,14 @@ final class Path {
     static Path newPath(String path) {
         return PathParser.parsePath(path);
     }
+
+    public List<String> toUnmodifiableJava() {
+        List<String> ls = new LinkedList<>();
+        Path here = this;
+        while (here != null) {
+            ls.add(here.first);
+            here = here.remainder;
+        }
+        return Collections.unmodifiableList(ls);
+    }
 }

--- a/config/src/main/java/com/typesafe/config/impl/PathParser.java
+++ b/config/src/main/java/com/typesafe/config/impl/PathParser.java
@@ -30,11 +30,11 @@ final class PathParser {
 
     static ConfigOrigin apiOrigin = SimpleConfigOrigin.newSimple("path parameter");
 
-    static ConfigNodePath parsePathNode(String path) {
+    static ConfigNodeParsedPath parsePathNode(String path) {
         return parsePathNode(path, ConfigSyntax.CONF);
     }
 
-    static ConfigNodePath parsePathNode(String path, ConfigSyntax flavor) {
+    static ConfigNodeParsedPath parsePathNode(String path, ConfigSyntax flavor) {
         StringReader reader = new StringReader(path);
 
         try {
@@ -74,16 +74,16 @@ final class PathParser {
         return parsePathExpression(expression, origin, originalText, null, ConfigSyntax.CONF);
     }
 
-    protected static ConfigNodePath parsePathNodeExpression(Iterator<Token> expression,
+    protected static ConfigNodeParsedPath parsePathNodeExpression(Iterator<Token> expression,
                                                             ConfigOrigin origin) {
         return parsePathNodeExpression(expression, origin, null, ConfigSyntax.CONF);
     }
 
-    protected static ConfigNodePath parsePathNodeExpression(Iterator<Token> expression,
+    protected static ConfigNodeParsedPath parsePathNodeExpression(Iterator<Token> expression,
                                                             ConfigOrigin origin, String originalText, ConfigSyntax flavor) {
         ArrayList<Token> pathTokens = new ArrayList<Token>();
         Path path = parsePathExpression(expression, origin, originalText, pathTokens, flavor);
-        return new ConfigNodePath(path, pathTokens);
+        return new ConfigNodeParsedPath(path, pathTokens);
     }
 
     // originalText may be null if not available

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigDocument.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigDocument.java
@@ -1,10 +1,10 @@
 package com.typesafe.config.impl;
 
-import com.typesafe.config.*;
-import com.typesafe.config.parser.ConfigDocument;
-
 import java.io.StringReader;
 import java.util.Iterator;
+
+import com.typesafe.config.*;
+import com.typesafe.config.parser.ConfigDocument;
 
 final class SimpleConfigDocument implements ConfigDocument {
     private ConfigNodeRoot configNodeTree;
@@ -59,5 +59,10 @@ final class SimpleConfigDocument implements ConfigDocument {
     @Override
     public int hashCode() {
         return render().hashCode();
+    }
+
+    @Override
+    public com.typesafe.config.parser.ConfigNodeRoot getRoot() {
+        return configNodeTree;
     }
 }

--- a/config/src/main/java/com/typesafe/config/parser/AbstractConfigNodeVisitor.java
+++ b/config/src/main/java/com/typesafe/config/parser/AbstractConfigNodeVisitor.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Abstract class for visiting {@link ConfigNode}. Defaults all nodes to
+ * visitDefault. Implement and pass to
+ * {@link ConfigNode#accept(ConfigNodeVisitor)} to enumerate the CST/AST.
+ */
+public abstract class AbstractConfigNodeVisitor<T> implements ConfigNodeVisitor<T> {
+
+    @Override
+    public T visitRoot(ConfigNodeRoot node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitString(ConfigNodeString node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitArray(ConfigNodeArray node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitConcatenation(ConfigNodeConcatenation node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitField(ConfigNodeField node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitInclude(ConfigNodeInclude node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitObject(ConfigNodeObject node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitReference(ConfigNodeReference node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitNull(ConfigNodeNull node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitLong(ConfigNodeLong node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitInt(ConfigNodeInt node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitDouble(ConfigNodeDouble node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitBoolean(ConfigNodeBoolean node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitComment(ConfigNodeComment node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitPath(ConfigNodePath node) {
+        return visitDefault(node);
+    }
+
+    @Override
+    public T visitSyntax(ConfigNodeSyntax node) {
+        return visitDefault(node);
+    }
+
+    /**
+     * A node was visited, but the specific type wasn't overridden, at the current
+     * AST location.
+     * 
+     * @param node Node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    public abstract T visitDefault(ConfigNode node);
+
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigDocument.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigDocument.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.typesafe.config.parser;
 
 import com.typesafe.config.ConfigValue;
@@ -79,4 +95,11 @@ public interface ConfigDocument {
      * @return the modified original text
      */
     String render();
+
+    /**
+     * Returns the root node of this document's Abstract Syntax Tree (AST) for
+     * traversing and doing AST changes on.
+     * @return The AST root node
+     */
+    ConfigNodeRoot getRoot();
 }

--- a/config/src/main/java/com/typesafe/config/parser/ConfigDocumentFactory.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigDocumentFactory.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.typesafe.config.parser;
 
 import com.typesafe.config.ConfigParseOptions;

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNode.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNode.java
@@ -3,16 +3,15 @@
  */
 package com.typesafe.config.parser;
 
+import com.typesafe.config.ConfigOrigin;
+
 /**
  * A node in the syntax tree for a HOCON or JSON document.
- *
+ * 
  * <p>
- * Note: at present there is no way to obtain an instance of this interface, so
- * please ignore it. A future release will make syntax tree nodes available in
- * the public API. If you are interested in working on it, please see: <a
- * href="https://github.com/lightbend/config/issues/300"
- * >https://github.com/lightbend/config/issues/300</a>
- *
+ * The root node can be retrieved via {@link ConfigDocument#getRoot()}, and
+ * further nodes via manual seek or visitors.
+ * 
  * <p>
  * Because this object is immutable, it is safe to use from multiple threads and
  * there's no need for "defensive copies."
@@ -26,10 +25,26 @@ package com.typesafe.config.parser;
  */
 public interface ConfigNode {
     /**
-     * The original text of the input which was used to form this particular
-     * node.
+     * The original text of the input which was used to form this particular node.
      *
      * @return the original text used to form this node as a String
      */
     public String render();
+
+    /**
+     * Accepts a custom visitor for syntax tree traversal and returns the resulting
+     * value (if any).
+     * 
+     * @param <T>     Type of the return
+     * @param visitor Custom visitor returning T
+     * @return Result of calling visitor.visit*(this)
+     */
+    public <T> T accept(ConfigNodeVisitor<T> visitor);
+
+    /**
+     * Returns the location of the current node in the source file
+     * 
+     * @return origin location
+     */
+    public ConfigOrigin origin();
 }

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeArray.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeArray.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing an array value, as in JSON's
+ * {@code [1,2,3]} syntax.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeArray} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeArray}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeArray extends ConfigNodeComplex {
+
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeBoolean.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeBoolean.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing a bool value, as in JSON's
+ * {@code true} syntax.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeBoolean} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeBoolean}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeBoolean extends ConfigNode {
+
+    /**
+     * Returns the raw boolean value of this syntax node
+     * 
+     * @return raw boolean value
+     */
+    boolean getValue();
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeComment.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeComment.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing a comment in the HOCON.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeComment} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeComment}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeComment extends ConfigNode {
+
+    /**
+     * Returns the raw string of this comment node
+     * 
+     * @return raw comment string
+     */
+    String getValue();
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeComplex.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeComplex.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+import java.util.List;
+
+/**
+ * Abstract subtype of {@link ConfigNode} representing an AST node with
+ * children, such as {@link ConfigNodeArray}, {@link ConfigNodeObject}, etc.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeComplex} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeComplex}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeComplex extends ConfigNode {
+
+    /**
+     * Returns all children of this node
+     * 
+     * @return Children of this node
+     */
+    List<ConfigNode> getChildren();
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeConcatenation.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeConcatenation.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing a concatenation, as in HOCON's
+ * {@code "hello" "world"} syntax.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeConcatenation} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeConcatenation}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeConcatenation extends ConfigNodeComplex {
+
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeDouble.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeDouble.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing a double value, as in JSON's
+ * {@code 12.34} syntax.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeDouble} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeDouble}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeDouble extends ConfigNode {
+
+    /**
+     * Returns the raw double value of this syntax node
+     * 
+     * @return raw double value
+     */
+    double getValue();
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeField.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeField.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing a field in an object. Objects are
+ * list of Fields.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeField} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeField}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeField extends ConfigNode {
+
+    /**
+     * Returns the name component as a path
+     * 
+     * @return Path that this field represents
+     */
+    ConfigNodePath getPath();
+
+    /**
+     * Returns the value of this field node
+     * 
+     * @return Node value
+     */
+    ConfigNode getValue();
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeInclude.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeInclude.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing an include reference.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeInclude} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeInclude}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeInclude extends ConfigNodeComplex {
+
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeInt.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeInt.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing an int value, as in JSON's
+ * {@code 10000} syntax.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeInt} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeInt}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeInt extends ConfigNode {
+
+    /**
+     * Returns the raw integer value of this syntax node
+     * 
+     * @return raw integer value
+     */
+    int getValue();
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeLong.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeLong.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing a long value, as in JSON's
+ * {@code 100000000000} syntax.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeLong} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeLong}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeLong extends ConfigNode {
+
+    /**
+     * Returns the raw string of this syntax node
+     * 
+     * @return raw string value
+     */
+    long getValue();
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeNull.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeNull.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing a null value, as in JSON's
+ * {@code null} syntax.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeNull} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeNull}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeNull extends ConfigNode {
+
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeObject.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeObject.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing an object. Objects are list of
+ * Fields.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeObject} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeObject}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeObject extends ConfigNodeComplex {
+
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodePath.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodePath.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+import java.util.List;
+
+/**
+ * Subtype of {@link ConfigNode} representing a path value, as used by fields
+ * and references.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodePath} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodePath}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodePath extends ConfigNode {
+
+    /**
+     * Gets the concrete syntax nodes that are part of this path
+     * @return syntax nodes associated with this path
+     */
+    List<ConfigNodeSyntax> getSyntaxNodes();
+
+    /**
+     * Gets the path as a list of names
+     * @return path as a list of names
+     */
+    List<String> toList();
+
+    /**
+     * Gets the path as a dotted and escaped string
+     * @return path as a string
+     */
+    String toString();
+
+    /**
+     * Create a derived path from just the provided syntax nodes
+     * @param nodes List of syntax nodes that make up the path
+     * @return The derivative path
+     */
+    ConfigNodePath updateSyntax(List<ConfigNodeSyntax> nodes);
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeReference.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeReference.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing a reference value, as in HOCON's
+ * {@code ${hello.world}} syntax.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeNull} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeNull}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeReference extends ConfigNode {
+
+    /**
+     * Returns the path inside this node that this reference is referring to
+     * 
+     * @return referenced path
+     */
+    ConfigNodePath getPath();
+
+    /**
+     * Is this reference optional, ie does it start with '?'?
+     * 
+     * @return if this reference is optional
+     */
+    boolean isOptional();
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeRoot.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeRoot.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing the JSON root.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeRoot} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeRoot}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeRoot extends ConfigNodeComplex {
+
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeString.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeString.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing a string value, as in JSON's
+ * {@code "hello"} syntax.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeString} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeString}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeString extends ConfigNode {
+
+    /**
+     * Returns the raw string of this syntax node
+     * 
+     * @return raw string value
+     */
+    String getValue();
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeSyntax.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeSyntax.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Subtype of {@link ConfigNode} representing any syntactic elements in the
+ * parsed AST.
+ *
+ * <p>
+ * Like all {@link ConfigNode} subtypes, {@code ConfigNodeField} is immutable.
+ * This makes it threadsafe and you never have to create "defensive copies."
+ *
+ * <p>
+ * <em>Do not implement {@code ConfigNodeField}</em>; it should only be
+ * implemented by the config library. Arbitrary implementations will not work
+ * because the library internals assume a specific concrete implementation.
+ * Also, this interface is likely to grow new methods over time, so third-party
+ * implementations will break.
+ * 
+ */
+public interface ConfigNodeSyntax extends ConfigNode {
+
+    /**
+     * Gets the text of this syntax.
+     * 
+     * @return String of characters that represent this syntax element
+     */
+    String getText();
+
+    /**
+     * Gets the parsed value (if any, null otherwise) of this syntax node.
+     * 
+     * @return The parsed value or null of this syntax node.
+     */
+    ConfigNode getAnyValue();
+}

--- a/config/src/main/java/com/typesafe/config/parser/ConfigNodeVisitor.java
+++ b/config/src/main/java/com/typesafe/config/parser/ConfigNodeVisitor.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (C) 2011-2021, Config project contributors
+ *   
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.config.parser;
+
+/**
+ * Interface for visiting {@link ConfigNode}. Implement and pass to
+ * {@link ConfigNode#accept(ConfigNodeVisitor)} to enumerate the CST/AST.
+ * 
+ * Also see {@link AbstractConfigNodeVisitor}
+ */
+public interface ConfigNodeVisitor<T> {
+
+    /**
+     * Root node present at the current AST location
+     * 
+     * @param node Root Node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitRoot(ConfigNodeRoot node);
+
+    /**
+     * String value node present at the current AST location
+     * 
+     * @param node String value node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitString(ConfigNodeString node);
+
+    /**
+     * Array node present at the current AST location
+     * 
+     * @param node Array node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitArray(ConfigNodeArray node);
+
+    /**
+     * Concatenation node present at the current AST location
+     * 
+     * @param node Concatenation node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitConcatenation(ConfigNodeConcatenation node);
+
+    /**
+     * Object Field node present at the current AST location
+     * 
+     * @param node Object Field node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitField(ConfigNodeField node);
+
+    /**
+     * Include node present at the current AST location
+     * 
+     * @param node Include node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitInclude(ConfigNodeInclude node);
+
+    /**
+     * Object node present at the current AST location
+     * 
+     * @param node Object node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitObject(ConfigNodeObject node);
+
+    /**
+     * Value Reference node present at the current AST location
+     * 
+     * @param node Value Reference node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitReference(ConfigNodeReference node);
+
+    /**
+     * Null value node present at the current AST location
+     * 
+     * @param node Null value node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitNull(ConfigNodeNull node);
+
+    /**
+     * Long value node present at the current AST location
+     * 
+     * @param node Long value node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitLong(ConfigNodeLong node);
+
+    /**
+     * Integer value node present at the current AST location
+     * 
+     * @param node Integer value node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitInt(ConfigNodeInt node);
+
+    /**
+     * IEEE Double floating point value node present at the current AST location
+     * 
+     * @param node double value node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitDouble(ConfigNodeDouble node);
+
+    /**
+     * Boolean value node present at the current AST location
+     * 
+     * @param node Boolean value node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitBoolean(ConfigNodeBoolean node);
+
+    /**
+     * Comment node present at the current AST location. Always exposed via iteration on the children of a node (if present)
+     * 
+     * @param node String node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitComment(ConfigNodeComment node);
+
+    /**
+     * Path node present at the current AST location. Note this is redundant, as all
+     * places that provide a path are typed. As such this is provided for
+     * completeness only.
+     * 
+     * @param node Path node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitPath(ConfigNodePath node);
+
+    /**
+     * Syntax node present at the current AST location, if
+     * {@link ConfigNodeVisitor#includeSyntax()} is true.
+     * 
+     * @param node Syntax node
+     * @return user supplied value to return from
+     *         {@link ConfigNode#accept(ConfigNodeVisitor)}
+     */
+    T visitSyntax(ConfigNodeSyntax node);
+
+    /**
+     * Whether to return syntax nodes, or to skip them and return null from
+     * {@link ConfigNode#accept(ConfigNodeVisitor)}. If true, this is effectively an
+     * CST + AST visitor. If false, only visits the AST.
+     * 
+     * @return If Syntax nodes should be visited
+     */
+    boolean includeSyntax();
+
+}

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigNodeTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigNodeTest.scala
@@ -20,7 +20,7 @@ class ConfigNodeTest extends TestUtils {
         assertEquals(node.render(), token.tokenText())
     }
 
-    private def fieldNodeTest(key: ConfigNodePath, value: AbstractConfigNodeValue, newValue: AbstractConfigNodeValue) {
+    private def fieldNodeTest(key: ConfigNodeParsedPath, value: AbstractConfigNodeValue, newValue: AbstractConfigNodeValue) {
         val keyValNode = nodeKeyValuePair(key, value)
         assertEquals(key.render() + " : " + value.render(), keyValNode.render())
         assertEquals(key.render, keyValNode.path().render())

--- a/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
@@ -696,7 +696,7 @@ abstract trait TestUtils {
     def nodeComma = new ConfigNodeSingleToken(Tokens.COMMA)
     def nodeLine(line: Integer) = new ConfigNodeSingleToken(tokenLine(line))
     def nodeWhitespace(whitespace: String) = new ConfigNodeSingleToken(tokenWhitespace(whitespace))
-    def nodeKeyValuePair(key: ConfigNodePath, value: AbstractConfigNodeValue) = {
+    def nodeKeyValuePair(key: ConfigNodeParsedPath, value: AbstractConfigNodeValue) = {
         val nodes = List(key, nodeSpace, nodeColon, nodeSpace, value)
         new ConfigNodeField(nodes.asJavaCollection)
     }


### PR DESCRIPTION
This exposes an api for AST/CST interaction. I followed the general plan of attack as outlined in #300. Fixes #300

With these changes you can now edit HOCON files and preserve whitespace, comments, and variable references.