### PR TITLE
Allow passing HOCON string via system property

### DIFF
--- a/config/src/main/java/com/typesafe/config/ConfigFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigFactory.java
@@ -439,9 +439,9 @@ public final class ConfigFactory {
      */
     public static Config defaultOverrides() {
         if (getOverrideWithEnv()) {
-            return systemEnvironmentOverrides().withFallback(systemProperties());
+            return systemEnvironmentOverrides().withFallback(systemProperties().withFallback(configContentOverrides()));
         } else {
-            return systemProperties();
+            return systemProperties().withFallback(configContentOverrides());
         }
     }
 
@@ -669,6 +669,20 @@ public final class ConfigFactory {
      */
     public static Config systemEnvironment() {
         return ConfigImpl.envVariablesAsConfig();
+    }
+
+    /**
+     * Obtains <code>Config</code> by parsing content of reserved system property <code>config.config_content</code>.
+     * <code>Config</code> is parsed using default {@link ConfigParseOptions}
+     * <p>
+     *     Values parsed from <code>config.config_content</code>
+     *     can be overridden by other system properties or environment variables.
+     * </p>
+     *
+     * @return <code>Config</code>
+     */
+    public static Config configContentOverrides() {
+        return ConfigImpl.configContentOverrides();
     }
 
     /**

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigSubstitutionTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigSubstitutionTest.scala
@@ -1277,4 +1277,24 @@ class ConfigSubstitutionTest extends TestUtils {
         val resolved2 = resolve(obj2)
         assertEquals(parseObject("{ x : 42, y : 42 }"), resolved2.getConfig("a").root)
     }
+
+    @Test
+    def configContentPropertyOverridesConf(): Unit = {
+        val configContentProperty = "config.config_content"
+        val content = "array1=[]\nnull1=i_am_not_null_now\narray2=[\"Hello\", \"world!\"]"
+
+        try {
+            System.setProperty(configContentProperty, content)
+            ConfigImpl.reloadContentOverridesConfig()
+
+            val config = ConfigFactory.load("validate-reference.conf")
+
+            assertEquals(Seq(), config.getIntList("array1").asScala)
+            assertEquals(Seq("Hello", "world!"), config.getStringList("array2").asScala)
+            assertEquals("i_am_not_null_now", config.getString("null1"))
+            assertEquals(11, config.getInt("int2"))
+        } finally {
+            System.clearProperty(configContentProperty)
+        }
+    }
 }


### PR DESCRIPTION
References #380 

Hello! 
This PR provides implementation of [feature](https://github.com/lightbend/config/pull/382#issuecomment-206356034) proposed by @havocp in thread #382 

The goal is to have the ability to pass HOCON content as a string via system property `config.config_content`. 
Example: `-Dconfig.config_content="param1=Hello\nparam2=world!"`. 

This helps with some corner-case substitution scenarios, like passing empty list values via system props.