### PR TITLE
readme: change playground url

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,7 +939,7 @@ format.
 
 #### Online playground
 
-   * https://hocon-playground.herokuapp.com/
+   * https://hocon-playground.avelier.dev/
 
 # Maintenance notes
 


### PR DESCRIPTION
Hi. Long time ago I added playground url. It was hosted on heroku. But heroku shutting down free dynos. Therefore, I moved playground project to my own domain and host.

Old URL will stop working by the end of november.