### PR TITLE
Add ConfigFloat class to wrap java.lang.Float.

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigFloat.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigFloat.java
@@ -1,0 +1,61 @@
+/**
+ *   Copyright (C) 2011-2012 Typesafe Inc. <http://typesafe.com>
+ */
+package com.typesafe.config.impl;
+
+import com.typesafe.config.ConfigOrigin;
+import com.typesafe.config.ConfigValueType;
+
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+
+final class ConfigFloat extends ConfigNumber implements Serializable {
+
+    private static final long serialVersionUID = 2L;
+
+    final private float value;
+
+    ConfigFloat(ConfigOrigin origin, float value, String originalText) {
+        super(origin, originalText);
+        this.value = value;
+    }
+
+    @Override
+    public ConfigValueType valueType() {
+        return ConfigValueType.NUMBER;
+    }
+
+    @Override
+    public Float unwrapped() {
+        return value;
+    }
+
+    @Override
+    String transformToString() {
+        String s = super.transformToString();
+        if (s == null)
+            return Float.toString(value);
+        else
+            return s;
+    }
+
+    @Override
+    protected long longValue() {
+        return (long) value;
+    }
+
+    @Override
+    protected double doubleValue() {
+        return value;
+    }
+
+    @Override
+    protected ConfigFloat newCopy(ConfigOrigin origin) {
+        return new ConfigFloat(origin, value, originalText);
+    }
+
+    // serialization all goes through SerializedConfigValue
+    private Object writeReplace() throws ObjectStreamException {
+        return new SerializedConfigValue(this);
+    }
+}

--- a/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
@@ -233,6 +233,8 @@ public class ConfigImpl {
             // Double, Integer, or Long.
             if (object instanceof Double) {
                 return new ConfigDouble(origin, (Double) object, null);
+            } else if (object instanceof Float) {
+                return new ConfigFloat(origin, (Float) object, null);
             } else if (object instanceof Integer) {
                 return new ConfigInt(origin, (Integer) object, null);
             } else if (object instanceof Long) {

--- a/config/src/main/java/com/typesafe/config/impl/SerializedConfigValue.java
+++ b/config/src/main/java/com/typesafe/config/impl/SerializedConfigValue.java
@@ -85,6 +85,7 @@ class SerializedConfigValue extends AbstractConfigValue implements Externalizabl
         BOOLEAN(ConfigValueType.BOOLEAN),
         INT(ConfigValueType.NUMBER),
         LONG(ConfigValueType.NUMBER),
+        FLOAT(ConfigValueType.NUMBER),
         DOUBLE(ConfigValueType.NUMBER),
         STRING(ConfigValueType.STRING),
         LIST(ConfigValueType.LIST),
@@ -110,6 +111,8 @@ class SerializedConfigValue extends AbstractConfigValue implements Externalizabl
                     return INT;
                 else if (value instanceof ConfigLong)
                     return LONG;
+                else if (value instanceof ConfigFloat)
+                    return FLOAT;
                 else if (value instanceof ConfigDouble)
                     return DOUBLE;
             } else {
@@ -306,6 +309,10 @@ class SerializedConfigValue extends AbstractConfigValue implements Externalizabl
             out.writeLong(((ConfigLong) value).unwrapped());
             out.writeUTF(((ConfigNumber) value).transformToString());
             break;
+        case FLOAT:
+            out.writeFloat(((ConfigFloat) value).unwrapped());
+            out.writeUTF(((ConfigNumber) value).transformToString());
+            break;
         case DOUBLE:
             out.writeDouble(((ConfigDouble) value).unwrapped());
             out.writeUTF(((ConfigNumber) value).transformToString());
@@ -350,6 +357,10 @@ class SerializedConfigValue extends AbstractConfigValue implements Externalizabl
             long vl = in.readLong();
             String sl = in.readUTF();
             return new ConfigLong(origin, vl, sl);
+        case FLOAT:
+            float vf = in.readFloat();
+            String sf = in.readUTF();
+            return new ConfigFloat(origin, vf, sf);
         case DOUBLE:
             double vd = in.readDouble();
             String sd = in.readUTF();
@@ -468,7 +479,7 @@ class SerializedConfigValue extends AbstractConfigValue implements Externalizabl
             if (code == SerializedField.END_MARKER) {
                 return;
             }
-            
+
             DataInput input = fieldIn(in);
             if (code == SerializedField.ROOT_VALUE) {
                 this.value = readValue(input, null /* baseOrigin */);

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigValueTest.scala
@@ -422,6 +422,7 @@ class ConfigValueTest extends TestUtils {
         // isn't super important since it's just for debugging
         intValue(10).toString()
         longValue(11).toString()
+        floatValue(2.718f).toString()
         doubleValue(3.14).toString()
         stringValue("hi").toString()
         nullValue.toString()

--- a/config/src/test/scala/com/typesafe/config/impl/JsonTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/JsonTest.scala
@@ -41,6 +41,8 @@ class JsonTest extends TestUtils {
                 lift.JInt(BigInt(v.unwrapped()))
             case v: ConfigLong =>
                 lift.JInt(BigInt(v.unwrapped()))
+            case v: ConfigFloat =>
+                lift.JDouble(v.unwrapped().doubleValue())
             case v: ConfigDouble =>
                 lift.JDouble(v.unwrapped())
             case v: ConfigString =>

--- a/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/PublicApiTest.scala
@@ -131,6 +131,7 @@ class PublicApiTest extends TestUtils {
     def fromJavaNumbers() {
         testFromValue(intValue(5), 5: java.lang.Integer)
         testFromValue(longValue(6), 6: java.lang.Long)
+        testFromValue(floatValue(2.718f), 2.718f: java.lang.Float)
         testFromValue(doubleValue(3.14), 3.14: java.lang.Double)
 
         class WeirdNumber(v: Double) extends java.lang.Number {

--- a/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/TestUtils.scala
@@ -576,6 +576,7 @@ abstract trait TestUtils {
     protected def boolValue(b: Boolean) = new ConfigBoolean(fakeOrigin(), b)
     protected def nullValue = new ConfigNull(fakeOrigin())
     protected def stringValue(s: String) = new ConfigString.Quoted(fakeOrigin(), s)
+    protected def floatValue(f: Float) = new ConfigFloat(fakeOrigin(), f, null)
     protected def doubleValue(d: Double) = new ConfigDouble(fakeOrigin(), d, null)
 
     protected def parseObject(s: String) = {


### PR DESCRIPTION
Instances of java.lang.Float were previously wrapped using ConfigDouble. This had the unfortunate side effect of adding junk values when converting to double. For example float value `1.64e-7f` would be rendered as `1.6399999935856613E-7`.

This issue was discovered when testing the HOCON module of the Kotlin Serialization library.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here.
-->