### PR TITLE
CI on Java 17; GH action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - main
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,18 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: github.repository == 'lightbend/config'
     strategy:
       fail-fast: false
       matrix:
         include:
           - java: 8
           - java: 11
+          - java: 17
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
- Add Java 17 to the build matrix
- Use current major versions of the official GH actions