### PR TITLE
Handle one simple case of resolving list of += values which

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigConcatenation.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigConcatenation.java
@@ -24,7 +24,7 @@ import com.typesafe.config.ConfigValueType;
  */
 final class ConfigConcatenation extends AbstractConfigValue implements Unmergeable, Container {
 
-    final private List<AbstractConfigValue> pieces;
+    final List<AbstractConfigValue> pieces;
 
     ConfigConcatenation(ConfigOrigin origin, List<AbstractConfigValue> pieces) {
         super(origin);


### PR DESCRIPTION
Fixes #729 and significantly improves parsing of configs which have many `+=` array concatenations(large play application with many `play.modules.enabled`, for example)