### PR TITLE
Substituting environment variables fails when merging objects

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigConcatenation.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigConcatenation.java
@@ -290,4 +290,9 @@ final class ConfigConcatenation extends AbstractConfigValue implements Unmergeab
             p.render(sb, indent, atRoot, options);
         }
     }
+
+    public AbstractConfigValue getOverridePiece() {
+        return this.pieces.get(1);
+    }
+
 }

--- a/config/src/main/java/com/typesafe/config/impl/ConfigConcatenation.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigConcatenation.java
@@ -291,8 +291,8 @@ final class ConfigConcatenation extends AbstractConfigValue implements Unmergeab
         }
     }
 
-    public AbstractConfigValue getOverridePiece() {
-        return this.pieces.get(1);
+    public List<AbstractConfigValue> getPieces() {
+        return this.pieces;
     }
 
 }

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
@@ -214,15 +214,16 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
             }
             if (old.getValue() instanceof ConfigConcatenation) {
                 ConfigConcatenation configConcatenation = (ConfigConcatenation) old.getValue();
-                if (configConcatenation.getOverridePiece() == child) {
-                    if (replacement != null) {
-                        configConcatenation.replaceChild(child, replacement);
+                for (AbstractConfigValue piece: configConcatenation.getPieces()) {
+                    if (piece == child) {
+                        if (replacement != null) {
+                            configConcatenation.replaceChild(child, replacement);
+                        } else {
+                            // probably child should be removed from the concatenation
+                        }
+                        return new SimpleConfigObject(origin(), newChildren, ResolveStatus.fromValues(newChildren.values()),
+                                ignoresFallbacks);
                     }
-                    else {
-                        newChildren.remove(old.getKey());
-                    }
-                    return new SimpleConfigObject(origin(), newChildren, ResolveStatus.fromValues(newChildren.values()),
-                            ignoresFallbacks);
                 }
             }
         }

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
@@ -212,6 +212,19 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
                 return new SimpleConfigObject(origin(), newChildren, ResolveStatus.fromValues(newChildren.values()),
                         ignoresFallbacks);
             }
+            if (old.getValue() instanceof ConfigConcatenation) {
+                ConfigConcatenation configConcatenation = (ConfigConcatenation) old.getValue();
+                if (configConcatenation.getOverridePiece() == child) {
+                    if (replacement != null) {
+                        configConcatenation.replaceChild(child, replacement);
+                    }
+                    else {
+                        newChildren.remove(old.getKey());
+                    }
+                    return new SimpleConfigObject(origin(), newChildren, ResolveStatus.fromValues(newChildren.values()),
+                            ignoresFallbacks);
+                }
+            }
         }
         throw new ConfigException.BugOrBroken("SimpleConfigObject.replaceChild did not find " + child + " in " + this);
     }

--- a/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
+++ b/config/src/main/java/com/typesafe/config/impl/SimpleConfigObject.java
@@ -216,10 +216,12 @@ final class SimpleConfigObject extends AbstractConfigObject implements Serializa
                 ConfigConcatenation configConcatenation = (ConfigConcatenation) old.getValue();
                 for (AbstractConfigValue piece: configConcatenation.getPieces()) {
                     if (piece == child) {
-                        if (replacement != null) {
-                            configConcatenation.replaceChild(child, replacement);
-                        } else {
-                            // probably child should be removed from the concatenation
+                        ConfigConcatenation updatedConfigConcatenation = configConcatenation.replaceChild(child, replacement);
+                        if (updatedConfigConcatenation == null) {
+                            newChildren.remove(old.getKey());
+                        }
+                        else {
+                            old.setValue(updatedConfigConcatenation);
                         }
                         return new SimpleConfigObject(origin(), newChildren, ResolveStatus.fromValues(newChildren.values()),
                                 ignoresFallbacks);

--- a/config/src/test/resources/override-using-env-var-at-child-level.conf
+++ b/config/src/test/resources/override-using-env-var-at-child-level.conf
@@ -1,0 +1,16 @@
+prod {
+    catalog {
+        aws-access-key-id = [ "1" ]
+        aws-access-list-key-id = [ "1" ]
+    }
+}
+
+dev = ${prod} {
+    catalog {
+        aws-access-key-id = "2"
+        aws-access-key-id = ${?AWS_ACCESS_KEY_ID}
+
+        // but it works like
+        aws-access-list-key-id = [ "2", ${?AWS_ACCESS_KEY_ID} ]
+    }
+}

--- a/config/src/test/resources/override-using-env-var-at-child-level.conf
+++ b/config/src/test/resources/override-using-env-var-at-child-level.conf
@@ -10,7 +10,6 @@ dev = ${prod} {
         aws-access-key-id = "2"
         aws-access-key-id = ${?AWS_ACCESS_KEY_ID}
 
-        // but it works like
         aws-access-list-key-id = [ "2", ${?AWS_ACCESS_KEY_ID} ]
     }
 }

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
@@ -3,17 +3,15 @@
  */
 package com.typesafe.config.impl
 
-import java.math.BigInteger
-import java.time.temporal.{ ChronoUnit, TemporalUnit }
-
+import com.typesafe.config._
 import org.junit.Assert._
 import org.junit._
-import com.typesafe.config._
-import java.util.concurrent.TimeUnit
 
+import java.math.BigInteger
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit._
 import scala.collection.JavaConverters._
-import com.typesafe.config.ConfigResolveOptions
-import java.util.concurrent.TimeUnit.{ DAYS, HOURS, MICROSECONDS, MILLISECONDS, MINUTES, NANOSECONDS, SECONDS }
 
 class ConfigTest extends TestUtils {
 
@@ -1360,6 +1358,13 @@ class ConfigTest extends TestUtils {
             runFallbackTest("x=${a.b.c}", "x=${a.b.c}", false, new DummyResolver("x.", "", null))
         }
         assertTrue(e.getMessage.contains("${a.b.c}"))
+    }
+
+    @Test
+    def overrideUsingEnvVarAtChildLevel() {
+        val conf = ConfigFactory.load("override-using-env-var-at-child-level.conf")
+        assertEquals("2", conf.getList("dev.catalog.aws-access-key-id").get(0))
+        assertEquals("2", conf.getList("dev.catalog.aws-access-list-key-id").get(0))
     }
 
 }

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigTest.scala
@@ -1363,8 +1363,8 @@ class ConfigTest extends TestUtils {
     @Test
     def overrideUsingEnvVarAtChildLevel() {
         val conf = ConfigFactory.load("override-using-env-var-at-child-level.conf")
-        assertEquals("2", conf.getList("dev.catalog.aws-access-key-id").get(0))
-        assertEquals("2", conf.getList("dev.catalog.aws-access-list-key-id").get(0))
+        assertEquals("2", conf.getString("dev.catalog.aws-access-key-id"))
+        assertEquals(Seq("2"), conf.getStringList("dev.catalog.aws-access-list-key-id").asScala)
     }
 
 }


### PR DESCRIPTION
From the first glance it's related to
https://github.com/lightbend/config/issues/356
https://github.com/lightbend/config/issues/647
https://github.com/lightbend/config/issues/725

Here is an example of the config:
```
prod {
    catalog {
        aws-access-key-id = "1" 
        aws-access-list-key-id = [ "1" ]
    }
}

dev = ${prod} {
    catalog {
        # doesn't work
        aws-access-key-id = "2"
        aws-access-key-id = ${?AWS_ACCESS_KEY_ID}
        # but this one works
        aws-access-list-key-id = [ "2", ${?AWS_ACCESS_KEY_ID} ]
    }
}
```
Error:

Stack:
```
com.typesafe.config.ConfigException$BugOrBroken: SimpleConfigObject.replaceChild did not find SimpleConfigObjec
	at com.typesafe.config.impl.SimpleConfigObject.replaceChild(SimpleConfigObject.java:216)
	at com.typesafe.config.impl.SimpleConfigObject.replaceChild(SimpleConfigObject.java:26)
	at com.typesafe.config.impl.ResolveSource.replace(ResolveSource.java:192)
	at com.typesafe.config.impl.ResolveSource.replace(ResolveSource.java:193)
	at com.typesafe.config.impl.ResolveSource.replaceCurrentParent(ResolveSource.java:209)
	at com.typesafe.config.impl.ResolveSource.replaceWithinCurrentParent(ResolveSource.java:240)
	at com.typesafe.config.impl.ConfigDelayedMerge.resolveSubstitutions(ConfigDelayedMerge.java:110)
	at com.typesafe.config.impl.ConfigDelayedMerge.resolveSubstitutions(ConfigDelayedMerge.java:59)
	at com.typesafe.config.impl.ResolveContext.realResolve(ResolveContext.java:183)
	at com.typesafe.config.impl.ResolveContext.resolve(ResolveContext.java:146)
	at com.typesafe.config.impl.SimpleConfigObject$ResolveModifier.modifyChildMayThrow(SimpleConfigObject.java:380)
	at com.typesafe.config.impl.SimpleConfigObject.modifyMayThrow(SimpleConfigObject.java:313)
	at com.typesafe.config.impl.SimpleConfigObject.resolveSubstitutions(SimpleConfigObject.java:399)
	at com.typesafe.config.impl.ResolveContext.realResolve(ResolveContext.java:183)
	at com.typesafe.config.impl.ResolveContext.resolve(ResolveContext.java:146)
	at com.typesafe.config.impl.SimpleConfigObject$ResolveModifier.modifyChildMayThrow(SimpleConfigObject.java:380)
	at com.typesafe.config.impl.SimpleConfigObject.modifyMayThrow(SimpleConfigObject.java:313)
	at com.typesafe.config.impl.SimpleConfigObject.resolveSubstitutions(SimpleConfigObject.java:399)
	at com.typesafe.config.impl.ResolveContext.realResolve(ResolveContext.java:183)
	at com.typesafe.config.impl.ResolveContext.resolve(ResolveContext.java:146)
	at com.typesafe.config.impl.ConfigConcatenation.resolveSubstitutions(ConfigConcatenation.java:205)
	at com.typesafe.config.impl.ResolveContext.realResolve(ResolveContext.java:183)
	at com.typesafe.config.impl.ResolveContext.resolve(ResolveContext.java:146)
	at com.typesafe.config.impl.SimpleConfigObject$ResolveModifier.modifyChildMayThrow(SimpleConfigObject.java:380)
	at com.typesafe.config.impl.SimpleConfigObject.modifyMayThrow(SimpleConfigObject.java:313)
	at com.typesafe.config.impl.SimpleConfigObject.resolveSubstitutions(SimpleConfigObject.java:399)
	at com.typesafe.config.impl.ResolveContext.realResolve(ResolveContext.java:183)
	at com.typesafe.config.impl.ResolveContext.resolve(ResolveContext.java:146)
	at com.typesafe.config.impl.ResolveContext.resolve(ResolveContext.java:235)
	at com.typesafe.config.impl.SimpleConfig.resolveWith(SimpleConfig.java:79)
	at com.typesafe.config.impl.SimpleConfig.resolve(SimpleConfig.java:69)
	at com.typesafe.config.impl.SimpleConfig.resolve(SimpleConfig.java:42)
	at com.typesafe.config.ConfigFactory.load(ConfigFactory.java:219)
	at com.typesafe.config.ConfigFactory.load(ConfigFactory.java:119)
	at com.typesafe.config.ConfigFactory.load(ConfigFactory.java:79)
	at com.typesafe.config.impl.ConfigTest.overrideUsingEnvVarAtChildLevel(ConfigTest.scala:1367)
```
