### PR TITLE
Enable programmatic overriding of environment variables

### DIFF
--- a/config/src/main/java/com/typesafe/config/ConfigFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigFactory.java
@@ -1137,13 +1137,13 @@ public final class ConfigFactory {
 
         // override application.conf with config.file, config.resource,
         // config.url if requested.
-        String resource = System.getProperty("config.resource");
+        String resource = SystemOverride.getProperty("config.resource");
         if (resource != null)
             specified += 1;
-        String file = System.getProperty("config.file");
+        String file = SystemOverride.getProperty("config.file");
         if (file != null)
             specified += 1;
-        String url = System.getProperty("config.url");
+        String url = SystemOverride.getProperty("config.url");
         if (url != null)
             specified += 1;
 
@@ -1238,7 +1238,7 @@ public final class ConfigFactory {
     }
 
     private static ConfigLoadingStrategy getConfigLoadingStrategy() {
-        String className = System.getProperties().getProperty(STRATEGY_PROPERTY_NAME);
+        String className = SystemOverride.getProperties().getProperty(STRATEGY_PROPERTY_NAME);
 
         if (className != null) {
             try {
@@ -1256,7 +1256,7 @@ public final class ConfigFactory {
     }
 
     private static Boolean getOverrideWithEnv() {
-        String overrideWithEnv = System.getProperties().getProperty(OVERRIDE_WITH_ENV_PROPERTY_NAME);
+        String overrideWithEnv = SystemOverride.getProperties().getProperty(OVERRIDE_WITH_ENV_PROPERTY_NAME);
 
         return Boolean.parseBoolean(overrideWithEnv);
     }

--- a/config/src/main/java/com/typesafe/config/SystemOverride.java
+++ b/config/src/main/java/com/typesafe/config/SystemOverride.java
@@ -1,0 +1,144 @@
+package com.typesafe.config;
+
+import java.io.PrintStream;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Supplier;
+
+public class SystemOverride {
+
+    /** Runs the specified synchronous (blocking) operation
+     * guaranteeing that all SystemOverride methods return the specified values
+     * while the operation is being executed.
+     * <p>
+     * The configuration library only ever accesses System through SystemOverride,
+     * so this method is useful whenever you want to influence the configuration resolution
+     * through altering the environment variables (also system properties and standard error stream) programmatically.
+     *
+     * @param systemProperties replacement for the system properties
+     * @param environmentVariables replacement for the environment variables
+     * @param errorStream replacement for the standard error stream
+     *
+     * @return T the result of the specified operation
+     * @throws RuntimeException in case the specified operation throws
+     * */
+    public static <T> T withSystemOverride(
+            Map<String, String> systemProperties,
+            Map<String, String> environmentVariables,
+            PrintStream errorStream,
+            Supplier<T> configurationAccessOperation) {
+        SystemImplementation overridden = new OverriddenSystemImplementation(
+                systemProperties,
+                environmentVariables,
+                errorStream);
+        try {
+            current.set(overridden);
+            return configurationAccessOperation.get();
+        } finally {
+            current.set(real);
+        }
+    }
+
+    public static Properties getProperties() {
+        return current.get().getProperties();
+    }
+
+    public static String getProperty(String propertyKey) {
+        return current.get().getProperty(propertyKey);
+    }
+
+    public static String getenv(String environmentVariableName) {
+        return current.get().getenv(environmentVariableName);
+    }
+
+    public static Map<String, String> getenv() {
+        return current.get().getenv();
+    }
+
+    public static PrintStream err() {
+        return current.get().err();
+    }
+
+    private static interface SystemImplementation {
+        Properties getProperties();
+
+        String getProperty(String propertyKey);
+
+        String getenv(String environmentVariableName);
+
+        Map<String, String> getenv();
+
+        PrintStream err();
+
+    }
+
+    private static class LiveSystemImplementation implements SystemImplementation {
+        public Properties getProperties() {
+            return System.getProperties();
+        }
+
+        public String getProperty(String propertyKey) {
+            return System.getProperty(propertyKey);
+        }
+
+        public String getenv(String environmentVariableName) {
+            return System.getenv(environmentVariableName);
+        }
+
+        public Map<String, String> getenv() {
+            return System.getenv();
+        }
+
+        @Override
+        public PrintStream err() {
+            return System.err;
+        }
+
+
+    }
+
+    private static class OverriddenSystemImplementation implements SystemImplementation {
+
+        private final Map<String, String> systemProperties;
+        private final Map<String, String> environmentVariables;
+        private final PrintStream errorStream;
+
+        private OverriddenSystemImplementation(Map<String, String> systemProperties, Map<String, String> environmentVariables, PrintStream errorStream) {
+            this.systemProperties = systemProperties;
+            this.environmentVariables = environmentVariables;
+            this.errorStream = errorStream;
+        }
+
+        @Override
+        public Properties getProperties() {
+            Properties result = new Properties();
+            result.putAll(systemProperties);
+            return result;
+        }
+
+        @Override
+        public String getProperty(String propertyKey) {
+            return systemProperties.get(propertyKey);
+        }
+
+        @Override
+        public String getenv(String environmentVariableName) {
+            return environmentVariables.get(environmentVariableName);
+        }
+
+        @Override
+        public Map<String, String> getenv() {
+            return environmentVariables;
+        }
+
+        @Override
+        public PrintStream err() {
+            return errorStream;
+        }
+    }
+
+    private static final SystemImplementation real = new LiveSystemImplementation();
+
+    private static final ThreadLocal<SystemImplementation> current = ThreadLocal.withInitial(() -> real);
+
+}

--- a/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigImpl.java
@@ -25,6 +25,7 @@ import com.typesafe.config.ConfigOrigin;
 import com.typesafe.config.ConfigParseOptions;
 import com.typesafe.config.ConfigParseable;
 import com.typesafe.config.ConfigValue;
+import com.typesafe.config.SystemOverride;
 import com.typesafe.config.impl.SimpleIncluder.NameSource;
 
 /**
@@ -299,7 +300,7 @@ public class ConfigImpl {
 
     private static Properties getSystemProperties() {
         // Avoid ConcurrentModificationException due to parallel setting of system properties by copying properties
-        final Properties systemProperties = System.getProperties();
+        final Properties systemProperties = SystemOverride.getProperties();
         final Properties systemPropertiesCopy = new Properties();
         synchronized (systemProperties) {
             for (Map.Entry<Object, Object> entry: systemProperties.entrySet()) {
@@ -342,7 +343,7 @@ public class ConfigImpl {
     }
 
     private static AbstractConfigObject loadEnvVariables() {
-        return PropertiesParser.fromStringMap(newSimpleOrigin("env variables"), System.getenv());
+        return PropertiesParser.fromStringMap(newSimpleOrigin("env variables"), SystemOverride.getenv());
     }
 
     private static class EnvVariablesHolder {
@@ -370,8 +371,8 @@ public class ConfigImpl {
 
 
     private static AbstractConfigObject loadEnvVariablesOverrides() {
-        Map<String, String> env = new HashMap(System.getenv());
-        Map<String, String> result = new HashMap();
+        Map<String, String> env = new HashMap<>(SystemOverride.getenv());
+        Map<String, String> result = new HashMap<>();
 
         for (String key : env.keySet()) {
             if (key.startsWith(ENV_VAR_OVERRIDE_PREFIX)) {
@@ -453,7 +454,7 @@ public class ConfigImpl {
             result.put(SUBSTITUTIONS, false);
 
             // People do -Dconfig.trace=foo,bar to enable tracing of different things
-            String s = System.getProperty("config.trace");
+            String s = SystemOverride.getProperty("config.trace");
             if (s == null) {
                 return result;
             } else {
@@ -464,7 +465,7 @@ public class ConfigImpl {
                     } else if (k.equals(SUBSTITUTIONS)) {
                         result.put(SUBSTITUTIONS, true);
                     } else {
-                        System.err.println("config.trace property contains unknown trace topic '"
+                        SystemOverride.err().println("config.trace property contains unknown trace topic '"
                                 + k + "'");
                     }
                 }
@@ -503,15 +504,15 @@ public class ConfigImpl {
     }
 
     public static void trace(String message) {
-        System.err.println(message);
+        SystemOverride.err().println(message);
     }
 
     public static void trace(int indentLevel, String message) {
         while (indentLevel > 0) {
-            System.err.print("  ");
+            SystemOverride.err().print("  ");
             indentLevel -= 1;
         }
-        System.err.println(message);
+        SystemOverride.err().println(message);
     }
 
     // the basic idea here is to add the "what" and have a canonical


### PR DESCRIPTION
This new API allows users to easily test how environment variables substitutions would work in their complex configurations, with:
- no need for [ugly reflection hacks](https://stackoverflow.com/questions/318239/how-do-i-set-environment-variables-from-java) (JVM provides no way to alter env. variables)
- and without being forced to run their tests sequentially (as even with the hack, the env. variables are global).

Besides environment variables, the new API also lets one substitute system properties and standard error stream, everything in a scoped way (nothing is set globally, only per caller thread).

Caveat: the substitutions work only in the current thread, however, this should fit 99.9% of users, since it is rather unheard of, that one does multi-threaded computations during the configuration loading/resolving process.

References #796