### PR TITLE
Rendering a parsed config does not hold same results

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigReference.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigReference.java
@@ -153,7 +153,7 @@ final class ConfigReference extends AbstractConfigValue implements Unmergeable {
 
     @Override
     protected void render(StringBuilder sb, int indent, boolean atRoot, ConfigRenderOptions options) {
-        sb.append(expr.toString());
+        sb.append(expr.changePath(expr.path.subPath(prefixLength)).toString());
     }
 
     SubstitutionExpression expression() {


### PR DESCRIPTION
When rendering a parsed ConfigObject, in a scenario where there is a configuration like 

@config-file1.conf
include file("values.conf")
outer {
   include file("config-file2.conf") 
} 

@config-file2.conf 
inner = ${value.url} 

@values.conf 
value {
  url = "http://localhost"
}

the rendered ConfigObject after just Parseable.newFile("config-file2.conf").parse() has:

value {
   url = "http://localhost"
 }
outer {
   inner = ${ **outer**.value.url } 
} 
     
instead of what was actually read : 


value {
   url = "http://localhost"
 }
outer {
   inner = ${ value.url } 
} 

This means that if parsed back again and then later resolved, it will break because there is no **outer**.value.url. 
However, if resolved from the original file, it resolves correcly as inner=http://localhost (as expected). 
