### PR TITLE
#806 Skip ignoredWhitespaces when rendering concatenation

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigConcatenation.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigConcatenation.java
@@ -287,6 +287,9 @@ final class ConfigConcatenation extends AbstractConfigValue implements Unmergeab
     @Override
     protected void render(StringBuilder sb, int indent, boolean atRoot, ConfigRenderOptions options) {
         for (AbstractConfigValue p : pieces) {
+            if (isIgnoredWhitespace(p)) {
+                continue;
+            }
             p.render(sb, indent, atRoot, options);
         }
     }


### PR DESCRIPTION
A pull request for an issue:
https://github.com/lightbend/config/issues/806