### PR TITLE
update HOCON Playground link

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,7 +936,7 @@ format.
 
 #### Online playground
 
-   * https://hocon-playground.avelier.dev/
+   * https://hocon-playground.tehbrian.dev
 
 # Maintenance notes
 


### PR DESCRIPTION
The HOCON Playground site, [hocon-playground.avelier.dev](https://hocon-playground.avelier.dev), added in #560, is currently non-functional, returning a `Bad Gateway` error.

I forked the site, made considerable improvements (see [my fork's commits](https://github.com/TehBrian/hocon-playground/commits/master/)), and hosted it at [hocon-playground.tehbrian.dev](https://hocon-playground.tehbrian.dev). My fork has been useful for me (as I used the old site quite often), so I figured it'd be useful for others as well.