### PR TITLE
fix: Incorrect abs of hashes in BadMap

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/BadMap.java
+++ b/config/src/main/java/com/typesafe/config/impl/BadMap.java
@@ -74,7 +74,7 @@ final class BadMap<K,V> {
     }
 
     private static void store(Entry[] entries, Entry e) {
-        int i = e.hash % entries.length;
+        int i = Math.abs(e.hash % entries.length);
         Entry old = entries[i]; // old may be null
         if (old == null && e.next == null) {
             // share the entry since it has no "next"
@@ -100,8 +100,8 @@ final class BadMap<K,V> {
         if (entries.length == 0) {
             return null;
         } else {
-            int hash = Math.abs(k.hashCode());
-            int i = hash % entries.length;
+            int hash = k.hashCode();
+            int i = Math.abs(hash % entries.length);
             Entry e = entries[i];
             if (e == null)
                 return null;

--- a/config/src/test/scala/com/typesafe/config/impl/BadMapTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/BadMapTest.scala
@@ -88,6 +88,20 @@ class BadMapTest extends TestUtils {
         }
     }
 
+    @Test
+    def negativeEntryHash(): Unit = {
+        class Key(value: Int) {
+            override def hashCode(): Int = value
+        }
+
+        var map = new BadMap[Key, String]()
+        val negativeHashKey = new Key(Integer.MIN_VALUE)
+        map = map.copyingPut(negativeHashKey, "value")
+          .copyingPut(new Key(2), "other value")
+          .copyingPut(new Key(3), "yet another value")
+        assertEquals(map.get(negativeHashKey), "value")
+    }
+
     private class UniqueKeyWithHash(hash: Int) {
         override def hashCode(): Int = hash
     }


### PR DESCRIPTION
Can lead to negative array indexes and throw out of bounds exception on config load