### PR TITLE
build: bump actions to get sbt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
           - java: 11
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
Build broken right now because it can't find sbt installed (we'll need to merge this before we can know if it sorts the build)

Example build fail output:
```
Run sbt -v test doc
/home/runner/work/_temp/3a0119bd-4688-42f2-a996-9dee91f5126f.sh: line 1: sbt: command not found
Error: Process completed with exit code 127.
```
https://github.com/lightbend/config/actions/runs/15529492735/job/43715213268#step:4:1