### PR TITLE
build: Modernize, use sbt-ci-release for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: CI
+on:
+  push:
+    tags: ["v*"]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: github.repository == 'lightbend/config'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+      - env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        run: sbt ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,6 @@ ThisBuild / description             := "configuration library for JVM languages 
 ThisBuild / licenses                := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0"))
 ThisBuild / homepage                := Option(url("https://github.com/lightbend/config"))
 ThisBuild / pomIncludeRepository    := { _ => false }
-ThisBuild / publishTo               := {
-  val nexus = "https://oss.sonatype.org/"
-  if ((ThisBuild / isSnapshot).value) Option("Sonatype OSS Snapshots" at nexus + "content/repositories/snapshots")
-  else Option("Sonatype OSS Staging" at nexus + "service/local/staging/deploy/maven2")
-}
 ThisBuild / publishMavenStyle       := true
 
 lazy val root = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -86,8 +86,6 @@ lazy val configLib =  Project("config", file("config"))
     ),
 
     OsgiKeys.exportPackage                 := Seq("com.typesafe.config", "com.typesafe.config.impl"),
-    publish                                := sys.error("use publishSigned instead of plain publish"),
-    publishLocal                           := sys.error("use publishLocalSigned instead of plain publishLocal"),
     Compile / packageBin / packageOptions  +=
       Package.ManifestAttributes("Automatic-Module-Name" -> "typesafe.config" )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,3 @@
-// to release, bump major/minor/micro as appropriate,
-// update NEWS, update version in README.md, tag, then
-// publishSigned.
-// Release tags should follow: http://semver.org/
-import scalariform.formatter.preferences._
-
 ThisBuild / git.baseVersion         := "1.4.0"
 ThisBuild / organization            := "com.typesafe"
 ThisBuild / Compile / scalacOptions := List("-unchecked", "-deprecation", "-feature")
@@ -40,49 +34,39 @@ lazy val root = (project in file("."))
     simpleLibJava, simpleAppJava, complexAppJava
   )
   .settings(commonSettings)
-  .settings(nocomma {
-    name                                   := "config-root"
-    git.baseVersion                        := (ThisBuild / git.baseVersion).value
-    doc / aggregate                        := false
-    doc                                    := (configLib / Compile / doc).value
-    packageDoc / aggregate                 := false
+  .settings(
+    name                                   := "config-root",
+    git.baseVersion                        := (ThisBuild / git.baseVersion).value,
+    doc / aggregate                        := false,
+    doc                                    := (configLib / Compile / doc).value,
+    packageDoc / aggregate                 := false,
     packageDoc                             := (configLib / Compile / packageDoc).value
-    checkstyle / aggregate                 := false
-    checkstyle                             := (configLib / Compile / checkstyle).value
-    useGpg                                 := true
-    PgpKeys.publishSigned / aggregate      := false
-    PgpKeys.publishSigned                  := (PgpKeys.publishSigned in configLib).value
-    PgpKeys.publishLocalSigned / aggregate := false
-    PgpKeys.publishLocalSigned             := (PgpKeys.publishLocalSigned in configLib).value
-  })
+  )
 
 lazy val configLib =  Project("config", file("config"))
   .enablePlugins(SbtOsgi)
   .dependsOn(testLib % "test->test")
   .settings(osgiSettings)
-  .settings(nocomma {
-    autoScalaLibrary                       := false
-    crossPaths                             := false
-    libraryDependencies                    += "net.liftweb" %% "lift-json" % "3.3.0" % Test
-    libraryDependencies                    += "com.novocode" % "junit-interface" % "0.11" % Test
+  .settings(
+    autoScalaLibrary                       := false,
+    crossPaths                             := false,
+    libraryDependencies                    += "net.liftweb" %% "lift-json" % "3.3.0" % Test,
+    libraryDependencies                    += "com.novocode" % "junit-interface" % "0.11" % Test,
 
     Compile / compile / javacOptions       ++= Seq("-source", "1.8", "-target", "1.8",
-                                                   "-g", "-Xlint:unchecked")
+                                                   "-g", "-Xlint:unchecked"),
 
     Compile / doc / javacOptions           ++= Seq("-group", s"Public API (version ${version.value})", "com.typesafe.config:com.typesafe.config.parser",
-                                                   "-group", "Internal Implementation - Not ABI Stable", "com.typesafe.config.impl")
-    javadocSourceBaseUrl := {
-      for (gitHead <- com.typesafe.sbt.SbtGit.GitKeys.gitHeadCommit.value)
-        yield s"https://github.com/lightbend/config/blob/$gitHead/config/src/main/java"
-    }
+                                                   "-group", "Internal Implementation - Not ABI Stable", "com.typesafe.config.impl"),
+    javadocSourceBaseUrl := Some("https://github.com/lightbend/config/tree/main/config/src/main/java"),
     // because we test some global state such as singleton caches,
     // we have to run tests in serial.
-    Test / parallelExecution               := false
+    Test / parallelExecution               := false,
 
-    test / fork                            := true
-    Test / fork                            := true
-    run / fork                             := true
-    Test/ run / fork                       := true
+    test / fork                            := true,
+    Test / fork                            := true,
+    run / fork                             := true,
+    Test/ run / fork                       := true,
 
     //env vars for tests
     Test / envVars                         ++= Map("testList.0" -> "0",
@@ -99,63 +83,17 @@ lazy val configLib =  Project("config", file("config"))
       "SECRET_A" -> "A", // ConfigTest.renderShowEnvVariableValues
       "SECRET_B" -> "B", // ConfigTest.renderShowEnvVariableValues
       "SECRET_C" -> "C" // ConfigTest.renderShowEnvVariableValues
-    )
+    ),
 
-    OsgiKeys.exportPackage                 := Seq("com.typesafe.config", "com.typesafe.config.impl")
-    publish                                := sys.error("use publishSigned instead of plain publish")
-    publishLocal                           := sys.error("use publishLocalSigned instead of plain publishLocal")
+    OsgiKeys.exportPackage                 := Seq("com.typesafe.config", "com.typesafe.config.impl"),
+    publish                                := sys.error("use publishSigned instead of plain publish"),
+    publishLocal                           := sys.error("use publishLocalSigned instead of plain publishLocal"),
     Compile / packageBin / packageOptions  +=
       Package.ManifestAttributes("Automatic-Module-Name" -> "typesafe.config" )
-    scalariformPreferences                 := scalariformPreferences.value
-      .setPreference(IndentSpaces, 4)
-      .setPreference(FirstArgumentOnNewline, Preserve)
-
-    checkstyleConfigLocation               := CheckstyleConfigLocation.File((baseDirectory.value / "checkstyle-config.xml").toString)
-
-    Compile / checkstyle := {
-      val log = streams.value.log
-      (Compile / checkstyle).value
-      val resultFile = (Compile / checkstyleOutputFile).value
-      val results = scala.xml.XML.loadFile(resultFile)
-      val errorFiles = results \\ "checkstyle" \\ "file"
-
-      def errorFromXml(node: scala.xml.NodeSeq): (String, String, String) = {
-        val line: String = (node \ "@line" text)
-        val msg: String = (node \ "@message" text)
-        val source: String = (node \ "@source" text)
-        (line, msg, source)
-      }
-      def errorsFromXml(fileNode: scala.xml.NodeSeq): Seq[(String, String, String, String)] = {
-        val name: String = (fileNode \ "@name" text)
-        val errors = (fileNode \\ "error") map { e => errorFromXml(e) }
-        errors map { case (line, error, source) => (name, line, error, source) }
-      }
-
-      val errors = errorFiles flatMap { f => errorsFromXml(f) }
-
-      if (errors.nonEmpty) {
-        for (e <- errors) {
-          log.error(s"${e._1}:${e._2}: ${e._3} (from ${e._4})")
-        }
-        throw new RuntimeException(s"Checkstyle failed with ${errors.size} errors")
-      }
-      log.info("No errors from checkstyle")
-    }
-
-    // add checkstyle as a dependency of doc
-    Compile / doc                          := ((Compile / doc).dependsOn(Compile / checkstyle)).value
-
-    findbugsReportType                     := Some(FindbugsReport.Html)
-    findbugsReportPath                     := Some(crossTarget.value / "findbugs.html")
-    findbugsEffort                         := FindbugsEffort.Maximum
-    findbugsMaxMemory                      := 2000
-  })
+  )
 
 lazy val commonSettings: Seq[Setting[_]] = Def.settings(
   unpublished,
-  scalariformPreferences := scalariformPreferences.value
-    .setPreference(IndentSpaces, 4)
-    .setPreference(FirstArgumentOnNewline, Preserve),
   Compile / compile / javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
 )
 

--- a/config/src/main/java/com/typesafe/config/ConfigFactory.java
+++ b/config/src/main/java/com/typesafe/config/ConfigFactory.java
@@ -618,9 +618,10 @@ public final class ConfigFactory {
      * <p>
      * Environment variables are mangled in the following way after stripping the prefix "CONFIG_FORCE_":
      * <table border="1">
+     *   <caption>environment variables</caption>
      * <tr>
-     *     <th bgcolor="silver">Env Var</th>
-     *     <th bgcolor="silver">Config</th>
+     *     <th>Env Var</th>
+     *     <th>Config</th>
      * </tr>
      * <tr>
      *     <td>_&nbsp;&nbsp;&nbsp;[1 underscore]</td>

--- a/config/src/main/java/com/typesafe/config/impl/package.html
+++ b/config/src/main/java/com/typesafe/config/impl/package.html
@@ -6,7 +6,7 @@
 -->
 
 </head>
-<body bgcolor="white">
+<body>
 
 <p>
 Internal implementation details that can change ABI at any time.

--- a/config/src/main/java/com/typesafe/config/package.html
+++ b/config/src/main/java/com/typesafe/config/package.html
@@ -6,7 +6,7 @@
 -->
 
 </head>
-<body bgcolor="white">
+<body>
 
 <p>
 An API for loading and using configuration files, see <a href="https://github.com/lightbend/config/">the project site</a>

--- a/config/src/main/java/com/typesafe/config/parser/package.html
+++ b/config/src/main/java/com/typesafe/config/parser/package.html
@@ -6,7 +6,7 @@
 -->
 
 </head>
-<body bgcolor="white">
+<body>
 
 <p>
 This package supplies a raw parser and syntax tree for individual HOCON and JSON

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.11.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,3 @@
-addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
-addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.1.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0-M2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.3")
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.1.1")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
-addSbtPlugin("com.eed3si9n" % "sbt-nocomma" % "0.1.0")
+addSbtPlugin("com.github.sbt"    % "sbt-ci-release"     % "1.9.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.3")
 
-addSbtPlugin("com.github.sbt"    % "sbt-ci-release"     % "1.9.3")
+addSbtPlugin("com.github.sbt"    % "sbt-ci-release"     % "1.11.1")


### PR DESCRIPTION
Drops all the ancient formatting/findbugs/test coverage stuff and bumps sbt to latest. Adds an initial publish/release CI job that may need further iterations (or we are lucky and just need to add credentials to the repo)